### PR TITLE
fix(safety): blocklist refuses parent folder + clearer 0-results UX

### DIFF
--- a/cleanacelerai/src/services/duplicate_finder.py
+++ b/cleanacelerai/src/services/duplicate_finder.py
@@ -86,8 +86,10 @@ def find_duplicates(
             if CARPETAS_SISTEMA.intersection(normalizar_ruta(root)):
                 continue
 
-            # Skip globally blocked paths (dev/project folders)
-            root_norm = os.path.normpath(root).lower()
+            # Skip globally blocked paths (dev/project folders).
+            # Trailing sep makes blocklist entries like '\Mis_proyectos\' also
+            # match a root that is exactly the blocked folder ('D:\Mis_proyectos').
+            root_norm = os.path.normpath(root).lower() + os.sep
             if any(blocked.lower() in root_norm for blocked in PATHS_BLOQUEADOS_SCAN):
                 dirs.clear()
                 continue

--- a/cleanacelerai/src/ui/presenters/duplicates_presenter.py
+++ b/cleanacelerai/src/ui/presenters/duplicates_presenter.py
@@ -28,8 +28,9 @@ class DuplicatesPresenter:
         """
         Return True if the given path matches any entry in PATHS_BLOQUEADOS_SCAN.
 
-        Normalizes separators before comparing so forward-slash and
-        backslash paths are both handled correctly.
+        Normalizes separators and appends a trailing separator before comparing,
+        so blocklist entries like '\\Mis_proyectos\\' also match a path that is
+        exactly the blocked folder (e.g. 'D:\\Mis_proyectos').
 
         Args:
             path: Folder path chosen by the user.
@@ -38,7 +39,7 @@ class DuplicatesPresenter:
             True if the path must be refused.
         """
         import os
-        path_norm = os.path.normpath(path).lower()
+        path_norm = os.path.normpath(path).lower() + os.sep
         return any(blocked.lower() in path_norm for blocked in PATHS_BLOQUEADOS_SCAN)
 
     def set_protection(
@@ -112,6 +113,13 @@ class DuplicatesPresenter:
 
             self.view.add_duplicate_group(group, evaluaciones)
             grupos_count += 1
+
+        if grupos_count == 0:
+            self.view.log(
+                "No se encontraron duplicados eliminables. "
+                "Si esperabas resultados, revisa que la carpeta no contenga código de proyecto "
+                "(estarían protegidos) y que tenga archivos > 1 KB."
+            )
 
         self.view.on_scan_finished(grupos_count)
 

--- a/cleanacelerai/src/ui/views/duplicates_view.py
+++ b/cleanacelerai/src/ui/views/duplicates_view.py
@@ -141,11 +141,25 @@ class DuplicatesView(ctk.CTkFrame):
                                  font=("Segoe UI", 9, "bold"), foreground=COLOR_TEXT_MAIN)
         self._tree.grid(row=1, column=0, sticky="nsew", padx=20, pady=(0, 10))
 
+        marco_consola = ctk.CTkFrame(tarjeta, fg_color="transparent")
+        marco_consola.grid(row=2, column=0, sticky="ew", padx=20, pady=(0, 15))
+        marco_consola.grid_columnconfigure(0, weight=1)
+
         self._consola = tk.Text(
-            tarjeta, height=2, font=("Consolas", 9),
-            bg=COLOR_BG, fg=COLOR_TEXT_MUTED, borderwidth=0,
+            marco_consola,
+            height=7,
+            font=("Consolas", 9),
+            bg=COLOR_BG, fg=COLOR_TEXT_MUTED,
+            borderwidth=0,
+            wrap="word",
         )
-        self._consola.grid(row=2, column=0, sticky="ew", padx=20, pady=(0, 15))
+        self._consola.grid(row=0, column=0, sticky="ew")
+
+        scroll_consola = ttk.Scrollbar(
+            marco_consola, orient="vertical", command=self._consola.yview,
+        )
+        scroll_consola.grid(row=0, column=1, sticky="ns")
+        self._consola.configure(yscrollcommand=scroll_consola.set)
 
     def _build_context_menu(self) -> None:
         self._menu_ctx = Menu(self, tearoff=0, bg=COLOR_CARD, fg=COLOR_TEXT_MAIN)

--- a/cleanacelerai/tests/test_path_blocklist.py
+++ b/cleanacelerai/tests/test_path_blocklist.py
@@ -83,3 +83,22 @@ class TestPresenterIsPathBlocked:
     def test_dist_folder_is_blocked(self) -> None:
         p = make_presenter()
         assert p.is_path_blocked(r"D:\projects\app\dist\index.js")
+
+    # ── Regression: parent folder picked exactly, no trailing separator ──
+    def test_mis_proyectos_parent_exact_is_blocked(self) -> None:
+        """User can pick D:\\Mis_proyectos itself — must still be refused."""
+        p = make_presenter()
+        assert p.is_path_blocked(r"D:\Mis_proyectos")
+
+    def test_local_sites_parent_exact_is_blocked(self) -> None:
+        """User can pick C:\\Users\\Josep\\Local Sites itself — must still be refused."""
+        p = make_presenter()
+        assert p.is_path_blocked(r"C:\Users\Josep\Local Sites")
+
+    def test_mis_proyectos_with_trailing_sep_is_blocked(self) -> None:
+        p = make_presenter()
+        assert p.is_path_blocked("D:\\Mis_proyectos\\")
+
+    def test_venv_parent_exact_is_blocked(self) -> None:
+        p = make_presenter()
+        assert p.is_path_blocked(r"D:\projects\myapp\venv")


### PR DESCRIPTION
## Summary

- `is_path_blocked` and the `os.walk` loop in `duplicate_finder` were not refusing a scan source picked at the **exact blocked folder** (e.g. `D:\Mis_proyectos` or `C:\Users\Josep\Local Sites` without trailing separator). `os.path.normpath` strips trailing separators, so the substring `\Mis_proyectos\` never matched `d:\mis_proyectos`.
- Net effect: the protection popup never fired, the path entered the scan list, the walker traversed only the (empty) parent because subdirectories DID match the blocklist, and the UI showed `Resultados de la IA:` with nothing — silent failure from the user's perspective.

## Changes

- Append `os.sep` before substring match in `is_path_blocked()` and in the walk loop.
- Explicit `No se encontraron duplicados eliminables ...` message when the scan returns zero groups.
- Console widget in `DuplicatesView` grown from `height=2` to `height=7`, added `wrap="word"` and a vertical scrollbar so multi-line messages are readable.

## Test plan

- [x] `pytest cleanacelerai/tests/` — 135/135 pass (including 4 new regression tests for exact-parent picks)
- [x] Manual: pick `D:\Mis_proyectos` → "Ruta Bloqueada" popup fires, path is not added
- [x] Manual: pick `C:\Users\Josep\Local Sites` → same popup, refused
- [x] Manual: pick `C:\Users\Josep\Downloads` (no duplicates) → console clearly shows "No se encontraron duplicados eliminables ..."
- [x] Manual: console message wraps and is fully readable
