### PR TITLE
feat: 'Modo Assets Binarios' toggle for Duplicados IA

### DIFF
--- a/cleanacelerai/src/domain/constants.py
+++ b/cleanacelerai/src/domain/constants.py
@@ -48,18 +48,45 @@ ARCHIVOS_PROHIBIDOS: set[str] = {
     'pagefile.sys', 'hiberfil.sys', 'swapfile.sys', 'dumpstack.log',
 }
 
-# Folders that must never be scanned for deletion — contain project/dev code
-PATHS_BLOQUEADOS_SCAN: tuple[str, ...] = (
-    '\\Local Sites\\',
-    '\\Mis_proyectos\\',
-    '\\AppData\\Roaming\\Local\\',
+# Always-blocked tech paths — never reachable in any mode.
+# Includes \\AppData\\ (broadened from the buggy \\AppData\\Roaming\\Local\\ entry).
+PATHS_BLOQUEADOS_SCAN_TECH: tuple[str, ...] = (
     '\\.git\\',
     '\\node_modules\\',
     '\\venv\\',
     '\\.venv\\',
     '\\dist\\',
     '\\build\\',
+    '\\AppData\\',
 )
+
+# Project-content paths — blocked in normal mode, UNLOCKED in binary-assets mode.
+PATHS_BLOQUEADOS_SCAN_PROJECTS: tuple[str, ...] = (
+    '\\Local Sites\\',
+    '\\Mis_proyectos\\',
+)
+
+# Backward-compat alias. Existing callers (find_duplicates default,
+# DuplicatesPresenter.is_path_blocked normal mode, tests that patch the constant)
+# keep working WITHOUT changes because the union is identical in semantics.
+PATHS_BLOQUEADOS_SCAN: tuple[str, ...] = (
+    PATHS_BLOQUEADOS_SCAN_TECH + PATHS_BLOQUEADOS_SCAN_PROJECTS
+)
+
+# Whitelist applied at os.walk file level when binary-assets mode is active.
+# Lowercase ASCII extensions; matched via str.lower().endswith(tuple).
+EXTENSIONES_ASSETS_BINARIOS: tuple[str, ...] = (
+    '.png', '.jpg', '.jpeg', '.gif', '.webp', '.bmp', '.tiff', '.svg',
+    '.pdf',
+    '.mp4', '.mov', '.avi', '.mkv', '.webm',
+    '.mp3', '.wav', '.ogg', '.flac', '.m4a',
+    '.zip', '.rar', '.7z', '.iso', '.tar', '.gz',
+    '.psd', '.ai', '.sketch', '.fig', '.xd',
+)
+
+# Minimum file size floor used in binary-assets mode (50 KB).
+# Normal mode keeps the existing 1024 byte floor (passed as default kwarg).
+BINARY_MODE_SIZE_FLOOR_BYTES: int = 51_200
 
 # --- Intelligent Chaos Advisor ---
 from pathlib import Path

--- a/cleanacelerai/src/services/duplicate_finder.py
+++ b/cleanacelerai/src/services/duplicate_finder.py
@@ -41,6 +41,10 @@ def find_duplicates(
     protected_keywords: list[str] | None = None,
     on_progress: Callable[[str], None] | None = None,
     should_continue: Callable[[], bool] | None = None,
+    *,
+    blocked_paths: tuple[str, ...] | None = None,
+    allowed_extensions: tuple[str, ...] | None = None,
+    min_size_bytes: int = 1024,
 ) -> list[DuplicateGroup]:
     """
     Find duplicate files across the given paths.
@@ -55,6 +59,13 @@ def find_duplicates(
         protected_keywords: Keywords — folders containing these are skipped.
         on_progress: Optional callback for status messages.
         should_continue: Callable returning False to cancel mid-scan.
+        blocked_paths: Override for directory-level blocklist. Defaults to
+            PATHS_BLOQUEADOS_SCAN (full union). Resolved at call time so
+            unittest.mock.patch on the module-level constant still works.
+        allowed_extensions: Tuple of lowercase extensions to accept (e.g.
+            EXTENSIONES_ASSETS_BINARIOS). None means no extension filter.
+            Applied BEFORE os.path.getsize for safety + performance.
+        min_size_bytes: Files <= this size are skipped. Default 1024 (1 KB).
 
     Returns:
         List of DuplicateGroup, each with 2+ identical files.
@@ -63,6 +74,8 @@ def find_duplicates(
         protected_keywords = []
     if should_continue is None:
         should_continue = lambda: True
+    if blocked_paths is None:
+        blocked_paths = PATHS_BLOQUEADOS_SCAN
 
     def log(msg: str) -> None:
         if on_progress:
@@ -90,7 +103,7 @@ def find_duplicates(
             # Trailing sep makes blocklist entries like '\Mis_proyectos\' also
             # match a root that is exactly the blocked folder ('D:\Mis_proyectos').
             root_norm = os.path.normpath(root).lower() + os.sep
-            if any(blocked.lower() in root_norm for blocked in PATHS_BLOQUEADOS_SCAN):
+            if any(blocked.lower() in root_norm for blocked in blocked_paths):
                 dirs.clear()
                 continue
 
@@ -109,10 +122,15 @@ def find_duplicates(
                 if file.lower().endswith(EXTENSIONES_SISTEMA):
                     continue
 
+                # Extension whitelist gate — runs BEFORE getsize (safety + perf).
+                # None means no filter (default behavior, no extension rejected).
+                if allowed_extensions is not None and not file.lower().endswith(allowed_extensions):
+                    continue
+
                 filepath = os.path.join(root, file)
                 try:
                     size = os.path.getsize(filepath)
-                    if size > 1024:  # Ignore files < 1 KB
+                    if size > min_size_bytes:
                         archivos_por_tamano[size].append(filepath)
                     procesados += 1
                     if procesados % 100 == 0:

--- a/cleanacelerai/src/ui/main_window.py
+++ b/cleanacelerai/src/ui/main_window.py
@@ -41,11 +41,12 @@ class MainWindow(ctk.CTk):
 
         # Config persistence
         self._config_service = ConfigService()
-        _defaults = {
+        self._config_defaults = {
             "keywords": sorted(DOTFILES_CRITICOS),
             "folders": [],
+            "binary_assets_mode_enabled": False,
         }
-        self._config = self._config_service.load(_defaults)
+        self._config = self._config_service.load(self._config_defaults)
 
         # State for cross-callback coordination
         self._last_basura_count: int = 0
@@ -156,7 +157,10 @@ class MainWindow(ctk.CTk):
 
         self._dashboard_view = DashboardView(self._content)
         self._basura_view = BasuraView(self._content)
-        self._duplicates_view = DuplicatesView(self._content)
+        self._duplicates_view = DuplicatesView(
+            self._content,
+            initial_binary_mode=self._config.get("binary_assets_mode_enabled", False),
+        )
         self._asesor_view = AsesorView(self._content)
         self._marcadores_view = MarcadorView(self._content)
         self._renombrado_view = RenombradoView(self._content)
@@ -186,7 +190,11 @@ class MainWindow(ctk.CTk):
         self._basura_view.set_presenter(self._basura_presenter)
 
         # Duplicates
-        self._duplicates_presenter = DuplicatesPresenter(self._duplicates_view)
+        self._duplicates_presenter = DuplicatesPresenter(
+            self._duplicates_view,
+            config_service=self._config_service,
+            initial_binary_mode=self._config.get("binary_assets_mode_enabled", False),
+        )
         self._duplicates_presenter.set_protection(
             keywords=self._reglas_view.get_keywords(),
             folders=self._reglas_view.get_protected_folders(),
@@ -233,11 +241,16 @@ class MainWindow(ctk.CTk):
         # Update header title
         self._lbl_titulo.configure(text=self._TITULOS.get(nombre, nombre))
 
-        # Refresh presenter protection before switching to duplicados
+        # Refresh presenter protection and binary mode sync before switching to duplicados
         if nombre == "duplicados":
+            # Re-load config from disk so the tab always reflects on-disk state (Risk R6).
+            self._config = self._config_service.load(self._config_defaults)
             self._duplicates_presenter.set_protection(
                 keywords=self._reglas_view.get_keywords(),
                 folders=self._reglas_view.get_protected_folders(),
+            )
+            self._duplicates_view.sync_binary_mode_from_config(
+                self._config.get("binary_assets_mode_enabled", False),
             )
 
         # Show selected frame

--- a/cleanacelerai/src/ui/presenters/duplicates_presenter.py
+++ b/cleanacelerai/src/ui/presenters/duplicates_presenter.py
@@ -5,9 +5,15 @@ import datetime
 import threading
 from typing import TYPE_CHECKING, Callable
 
-from ...domain.constants import PATHS_BLOQUEADOS_SCAN
+from ...domain.constants import (
+    BINARY_MODE_SIZE_FLOOR_BYTES,
+    EXTENSIONES_ASSETS_BINARIOS,
+    PATHS_BLOQUEADOS_SCAN,
+    PATHS_BLOQUEADOS_SCAN_TECH,
+)
 from ...domain.models import DuplicateGroup, RiskLevel
 from ...domain.risk_evaluator import evaluate_file_risk, format_risk_label, get_risk_tag
+from ...infrastructure.config_service import ConfigService
 from ...infrastructure.file_system import open_in_explorer, safe_delete
 from ...services.duplicate_finder import find_duplicates
 
@@ -18,15 +24,26 @@ if TYPE_CHECKING:
 class DuplicatesPresenter:
     """Mediates between DuplicatesView and the duplicate-finder service."""
 
-    def __init__(self, view: "DuplicatesView") -> None:
+    def __init__(
+        self,
+        view: "DuplicatesView",
+        config_service: ConfigService | None = None,
+        initial_binary_mode: bool = False,
+    ) -> None:
         self.view = view
+        self._config_service = config_service
         self._scanning = False
         self._protected_keywords: list[str] = []
         self._protected_folders: list[str] = []
+        self._binary_mode: bool = initial_binary_mode
 
     def is_path_blocked(self, path: str) -> bool:
         """
-        Return True if the given path matches any entry in PATHS_BLOQUEADOS_SCAN.
+        Return True if the given path matches any entry in the effective blocklist.
+
+        In normal mode (binary_mode=False): checks against PATHS_BLOQUEADOS_SCAN
+        (full union). In binary mode: checks against PATHS_BLOQUEADOS_SCAN_TECH
+        only, so project paths like \\Mis_proyectos\\ and \\Local Sites\\ are allowed.
 
         Normalizes separators and appends a trailing separator before comparing,
         so blocklist entries like '\\Mis_proyectos\\' also match a path that is
@@ -40,7 +57,32 @@ class DuplicatesPresenter:
         """
         import os
         path_norm = os.path.normpath(path).lower() + os.sep
-        return any(blocked.lower() in path_norm for blocked in PATHS_BLOQUEADOS_SCAN)
+        blocklist = (
+            PATHS_BLOQUEADOS_SCAN_TECH
+            if self._binary_mode
+            else PATHS_BLOQUEADOS_SCAN
+        )
+        return any(blocked.lower() in path_norm for blocked in blocklist)
+
+    def set_binary_mode(self, enabled: bool) -> None:
+        """Update binary mode flag and persist to config. Surfaces save errors via the view."""
+        self._binary_mode = enabled
+        if self._config_service is None:
+            return
+        try:
+            current = self._config_service.load(defaults={})
+            current["binary_assets_mode_enabled"] = enabled
+            self._config_service.save(current)
+        except Exception as exc:  # OSError, PermissionError, JSONDecodeError, etc.
+            self.view.show_error(
+                "Error guardando configuración",
+                f"No se pudo guardar la preferencia de modo binario:\n\n{exc}\n\n"
+                "El modo está activo en esta sesión pero no persistirá al reiniciar.",
+            )
+
+    def is_auto_select_allowed(self) -> bool:
+        """Return False when binary mode is ON — auto-select is unsafe in that mode."""
+        return not self._binary_mode
 
     def set_protection(
         self,
@@ -55,11 +97,20 @@ class DuplicatesPresenter:
         """Start the duplicate scan in a background thread."""
         if not paths:
             return
+
+        # Snapshot mode at scan-start time (threading rule: worker never reads _binary_mode).
+        binary = self._binary_mode
+        blocked_paths = (
+            PATHS_BLOQUEADOS_SCAN_TECH if binary else PATHS_BLOQUEADOS_SCAN
+        )
+        allowed_extensions = EXTENSIONES_ASSETS_BINARIOS if binary else None
+        min_size = BINARY_MODE_SIZE_FLOOR_BYTES if binary else 1024
+
         self._scanning = True
         self.view.on_scan_started()
         threading.Thread(
             target=self._scan_worker,
-            args=(paths,),
+            args=(paths, blocked_paths, allowed_extensions, min_size),
             daemon=True,
         ).start()
 
@@ -67,12 +118,21 @@ class DuplicatesPresenter:
         """Signal the background thread to stop."""
         self._scanning = False
 
-    def _scan_worker(self, paths: list[str]) -> None:
+    def _scan_worker(
+        self,
+        paths: list[str],
+        blocked_paths: tuple[str, ...],
+        allowed_extensions: tuple[str, ...] | None,
+        min_size_bytes: int,
+    ) -> None:
         groups = find_duplicates(
             paths=paths,
             protected_keywords=self._protected_keywords,
             on_progress=self.view.log,
             should_continue=lambda: self._scanning,
+            blocked_paths=blocked_paths,
+            allowed_extensions=allowed_extensions,
+            min_size_bytes=min_size_bytes,
         )
         self.view.after(0, self._display_results, groups)
 

--- a/cleanacelerai/src/ui/views/duplicates_view.py
+++ b/cleanacelerai/src/ui/views/duplicates_view.py
@@ -27,27 +27,55 @@ if TYPE_CHECKING:
 class DuplicatesView(ctk.CTkFrame):
     """View for the duplicate-file finder module."""
 
-    def __init__(self, parent: ctk.CTkFrame) -> None:
+    def __init__(
+        self,
+        parent: ctk.CTkFrame,
+        initial_binary_mode: bool = False,
+    ) -> None:
         super().__init__(parent, fg_color="transparent")
-        self.grid_rowconfigure(2, weight=1)
+        # Row layout: 0=banner (binary mode only), 1=explanation, 2=controls, 3=results
+        self.grid_rowconfigure(3, weight=1)
         self.grid_columnconfigure(0, weight=1)
 
         self._presenter: DuplicatesPresenter | None = None
         self._rutas_analisis: list[str] = []
+        self._binary_mode_var = ctk.BooleanVar(value=initial_binary_mode)
 
-        self._build_explanation()
-        self._build_controls()
-        self._build_results()
+        self._build_banner_binary_mode()   # row 0 (hidden until mode ON)
+        self._build_explanation()          # row 1
+        self._build_controls()             # row 2 (checkbox added above paths list)
+        self._build_results()              # row 3
         self._build_context_menu()
+        self._refresh_binary_mode_visuals()
 
     def set_presenter(self, presenter: "DuplicatesPresenter") -> None:
         self._presenter = presenter
 
     # ── UI Construction ────────────────────────────────────────────────────
+    def _build_banner_binary_mode(self) -> None:
+        """Amber warning banner shown at top when binary assets mode is active."""
+        self._banner_binary_mode = ctk.CTkFrame(
+            self,
+            fg_color=COLOR_WARNING,
+            corner_radius=8,
+        )
+        # Row 0; initially hidden — shown by _refresh_binary_mode_visuals
+        self._banner_binary_mode.grid(row=0, column=0, padx=10, pady=(10, 0), sticky="ew")
+        ctk.CTkLabel(
+            self._banner_binary_mode,
+            text=(
+                "⚠️ MODO ASSETS BINARIOS ACTIVO — escanea carpetas de proyectos "
+                "solo para imágenes, vídeos, PDFs y archivos de diseño"
+            ),
+            text_color="#000000",
+            font=ctk.CTkFont(size=13, weight="bold"),
+        ).pack(padx=20, pady=8)
+        self._banner_binary_mode.grid_remove()  # hidden by default
+
     def _build_explanation(self) -> None:
         marco = ctk.CTkFrame(self, fg_color=COLOR_CARD, corner_radius=12,
                              border_width=1, border_color=COLOR_BORDER)
-        marco.grid(row=0, column=0, padx=10, pady=(0, 20), sticky="ew")
+        marco.grid(row=1, column=0, padx=10, pady=(0, 20), sticky="ew")
         ctk.CTkLabel(marco, text="💡 EXPLICACIÓN CLARA:",
                      font=ctk.CTkFont(weight="bold"), text_color=COLOR_ACCENT,
                      ).pack(anchor="w", padx=20, pady=(15, 5))
@@ -65,7 +93,22 @@ class DuplicatesView(ctk.CTkFrame):
     def _build_controls(self) -> None:
         tarjeta = ctk.CTkFrame(self, fg_color=COLOR_CARD, corner_radius=12,
                                border_width=1, border_color=COLOR_BORDER)
-        tarjeta.grid(row=1, column=0, padx=10, pady=(0, 10), sticky="ew")
+        tarjeta.grid(row=2, column=0, padx=10, pady=(0, 10), sticky="ew")
+
+        # Binary mode checkbox — above the paths list
+        marco_modo = ctk.CTkFrame(tarjeta, fg_color="transparent")
+        marco_modo.pack(fill="x", padx=20, pady=(15, 0))
+        self._chk_binary_mode = ctk.CTkCheckBox(
+            marco_modo,
+            text=(
+                "Modo Assets Binarios (escanear \\Mis_proyectos y \\Local Sites "
+                "solo en busca de imágenes/vídeos/PDFs)"
+            ),
+            variable=self._binary_mode_var,
+            command=self._on_toggle_binary_mode,
+            text_color=COLOR_TEXT_MAIN,
+        )
+        self._chk_binary_mode.pack(side="left")
 
         marco_rutas = ctk.CTkFrame(tarjeta, fg_color="transparent")
         marco_rutas.pack(fill="x", padx=20, pady=15)
@@ -102,17 +145,21 @@ class DuplicatesView(ctk.CTkFrame):
     def _build_results(self) -> None:
         tarjeta = ctk.CTkFrame(self, fg_color=COLOR_CARD, corner_radius=12,
                                border_width=1, border_color=COLOR_BORDER)
-        tarjeta.grid(row=2, column=0, padx=10, pady=(10, 0), sticky="nsew")
+        tarjeta.grid(row=3, column=0, padx=10, pady=(10, 0), sticky="nsew")
         tarjeta.grid_rowconfigure(1, weight=1)
         tarjeta.grid_columnconfigure(0, weight=1)
 
         marco_acciones = ctk.CTkFrame(tarjeta, fg_color="transparent")
         marco_acciones.grid(row=0, column=0, sticky="ew", padx=20, pady=15)
-        ctk.CTkButton(marco_acciones,
-                      text="✨ Auto-Seleccionar (Mantenimiento Inteligente)",
-                      command=self._on_auto_select,
-                      fg_color=COLOR_ACCENT, font=ctk.CTkFont(weight="bold"),
-                      ).pack(side="left")
+
+        self._btn_auto_select = ctk.CTkButton(
+            marco_acciones,
+            text="✨ Auto-Seleccionar (Mantenimiento Inteligente)",
+            command=self._on_auto_select,
+            fg_color=COLOR_ACCENT, font=ctk.CTkFont(weight="bold"),
+        )
+        self._btn_auto_select.pack(side="left")
+
         ctk.CTkButton(marco_acciones, text="🗑️ Eliminar Selección",
                       command=self._on_delete,
                       fg_color=COLOR_DANGER, font=ctk.CTkFont(weight="bold"),
@@ -167,6 +214,28 @@ class DuplicatesView(ctk.CTkFrame):
                                    command=self._on_open_location)
         self._tree.bind("<Button-3>", self._show_context_menu)
 
+    # ── Binary mode helpers ────────────────────────────────────────────────
+    def _on_toggle_binary_mode(self) -> None:
+        if self._presenter:
+            self._presenter.set_binary_mode(self._binary_mode_var.get())
+        self._refresh_binary_mode_visuals()
+
+    def _refresh_binary_mode_visuals(self) -> None:
+        """Re-sync every binary-mode-dependent widget. Called from __init__, toggle, and tab switch."""
+        on = self._binary_mode_var.get()
+        if on:
+            self._banner_binary_mode.grid()
+        else:
+            self._banner_binary_mode.grid_remove()
+        if self._presenter is not None:
+            allowed = self._presenter.is_auto_select_allowed()
+            self._btn_auto_select.configure(state="normal" if allowed else "disabled")
+
+    def sync_binary_mode_from_config(self, enabled: bool) -> None:
+        """Re-sync checkbox state from config (called by MainWindow on tab switch)."""
+        self._binary_mode_var.set(enabled)
+        self._refresh_binary_mode_visuals()
+
     # ── User event handlers ────────────────────────────────────────────────
     def _add_ruta(self) -> None:
         carpeta = filedialog.askdirectory()
@@ -185,8 +254,19 @@ class DuplicatesView(ctk.CTkFrame):
             self._lista_rutas.insert(tk.END, carpeta)
 
     def _on_start(self) -> None:
-        if self._presenter:
-            self._presenter.start_scan(self._rutas_analisis)
+        if not self._presenter:
+            return
+        if self._binary_mode_var.get():
+            confirmed = messagebox.askyesno(
+                "Modo Assets Binarios — Confirmación",
+                "Vas a escanear una carpeta de proyectos en MODO ASSETS BINARIOS.\n\n"
+                "Solo se buscarán imágenes, vídeos, PDFs y archivos de diseño "
+                "(> 50 KB). El código del proyecto está protegido por el filtro.\n\n"
+                "¿Confirmás que solo buscás assets?",
+            )
+            if not confirmed:
+                return
+        self._presenter.start_scan(self._rutas_analisis)
 
     def _on_cancel(self) -> None:
         if self._presenter:
@@ -206,10 +286,19 @@ class DuplicatesView(ctk.CTkFrame):
         seleccion = self._tree.selection()
         if not seleccion:
             return
-        if not messagebox.askyesno(
-            "Confirmar",
-            f"Vas a ELIMINAR PERMANENTEMENTE {len(seleccion)} archivos.\n¿Estás seguro?",
-        ):
+        if self._binary_mode_var.get():
+            msg = (
+                f"ATENCIÓN: estás eliminando {len(seleccion)} archivos detectados "
+                "en MODO ASSETS BINARIOS dentro de una carpeta de proyectos.\n\n"
+                "Verificá uno a uno antes de continuar. Esta acción es permanente.\n\n"
+                f"¿Eliminar {len(seleccion)} archivos?"
+            )
+        else:
+            msg = (
+                f"Vas a ELIMINAR PERMANENTEMENTE {len(seleccion)} archivos.\n"
+                "¿Estás seguro?"
+            )
+        if not messagebox.askyesno("Confirmar", msg):
             return
         if self._presenter:
             self._presenter.delete_selected()

--- a/cleanacelerai/tests/test_binary_mode_presenter.py
+++ b/cleanacelerai/tests/test_binary_mode_presenter.py
@@ -1,0 +1,188 @@
+"""Tests for DuplicatesPresenter binary mode state machine."""
+from __future__ import annotations
+
+import threading
+import time
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.ui.presenters.duplicates_presenter import DuplicatesPresenter
+
+
+class FakeView:
+    """Stub view that records calls for assertion."""
+
+    def __init__(self) -> None:
+        self.errors: list[tuple[str, str]] = []
+        self.scan_started: bool = False
+        self.scan_finished: bool = False
+
+    def show_error(self, title: str, message: str) -> None:
+        self.errors.append((title, message))
+
+    def on_scan_started(self) -> None:
+        self.scan_started = True
+
+    def on_scan_finished(self, count: int) -> None:
+        self.scan_finished = True
+
+    def after(self, ms: int, fn: object, *args: object) -> None:
+        # Execute immediately for synchronous test use
+        fn(*args)  # type: ignore[call-arg, operator]
+
+    def log(self, msg: str) -> None:
+        pass
+
+
+class FakeConfigService:
+    """Stub config service with controllable save failure."""
+
+    def __init__(self, initial_data: dict | None = None, raise_on_save: Exception | None = None) -> None:
+        self._data: dict = initial_data or {}
+        self._raise_on_save = raise_on_save
+
+    def load(self, defaults: dict) -> dict:
+        return {**defaults, **self._data}
+
+    def save(self, d: dict) -> None:
+        if self._raise_on_save is not None:
+            raise self._raise_on_save
+        self._data = dict(d)
+
+
+def make_presenter(
+    binary_mode: bool = False,
+    config_data: dict | None = None,
+    raise_on_save: Exception | None = None,
+) -> tuple[DuplicatesPresenter, FakeView, FakeConfigService]:
+    view = FakeView()
+    config = FakeConfigService(initial_data=config_data, raise_on_save=raise_on_save)
+    presenter = DuplicatesPresenter(
+        view,  # type: ignore[arg-type]
+        config_service=config,
+        initial_binary_mode=binary_mode,
+    )
+    return presenter, view, config
+
+
+class TestPresenterBinaryModeState:
+    """Verify _binary_mode state, set_binary_mode, and config persistence."""
+
+    def test_default_binary_mode_is_false(self) -> None:
+        presenter, _, _ = make_presenter()
+        assert presenter._binary_mode is False
+
+    def test_set_binary_mode_true(self) -> None:
+        presenter, _, _ = make_presenter()
+        presenter.set_binary_mode(True)
+        assert presenter._binary_mode is True
+
+    def test_set_binary_mode_false(self) -> None:
+        presenter, _, _ = make_presenter(binary_mode=True)
+        presenter.set_binary_mode(False)
+        assert presenter._binary_mode is False
+
+    def test_set_binary_mode_persists_to_config(self) -> None:
+        presenter, _, config = make_presenter()
+        presenter.set_binary_mode(True)
+        assert config._data.get("binary_assets_mode_enabled") is True
+
+    def test_set_binary_mode_false_persists(self) -> None:
+        presenter, _, config = make_presenter(binary_mode=True)
+        presenter.set_binary_mode(False)
+        assert config._data.get("binary_assets_mode_enabled") is False
+
+    def test_config_save_failure_shows_error(self) -> None:
+        presenter, view, _ = make_presenter(raise_on_save=OSError("disk full"))
+        presenter.set_binary_mode(True)
+        # _binary_mode must still be updated (in-memory flag is set before save attempt)
+        assert presenter._binary_mode is True
+        # view.show_error must have been called
+        assert len(view.errors) > 0
+        assert any("binario" in msg.lower() or "guardando" in title.lower()
+                   for title, msg in view.errors)
+
+    def test_initial_binary_mode_true_via_constructor(self) -> None:
+        presenter, _, _ = make_presenter(binary_mode=True)
+        assert presenter._binary_mode is True
+
+
+class TestPresenterIsPathBlockedModeAware:
+    """Verify is_path_blocked is mode-aware."""
+
+    def test_mode_off_blocks_mis_proyectos(self) -> None:
+        presenter, _, _ = make_presenter(binary_mode=False)
+        assert presenter.is_path_blocked(r"D:\Mis_proyectos") is True
+
+    def test_mode_on_allows_mis_proyectos(self) -> None:
+        presenter, _, _ = make_presenter(binary_mode=True)
+        assert presenter.is_path_blocked(r"D:\Mis_proyectos\photos") is False
+
+    def test_mode_on_still_blocks_node_modules_inside_project(self) -> None:
+        presenter, _, _ = make_presenter(binary_mode=True)
+        assert presenter.is_path_blocked(r"D:\Mis_proyectos\proj\node_modules") is True
+
+    def test_mode_on_still_blocks_appdata(self) -> None:
+        presenter, _, _ = make_presenter(binary_mode=True)
+        assert presenter.is_path_blocked(r"C:\Users\X\AppData\Local\Temp") is True
+
+    def test_mode_on_still_blocks_venv(self) -> None:
+        presenter, _, _ = make_presenter(binary_mode=True)
+        assert presenter.is_path_blocked(r"D:\Mis_proyectos\proj\venv") is True
+
+    def test_mode_off_blocks_local_sites(self) -> None:
+        presenter, _, _ = make_presenter(binary_mode=False)
+        assert presenter.is_path_blocked(r"C:\Users\Josep\Local Sites") is True
+
+    def test_mode_on_allows_local_sites(self) -> None:
+        presenter, _, _ = make_presenter(binary_mode=True)
+        assert presenter.is_path_blocked(r"C:\Users\Josep\Local Sites\mysite") is False
+
+
+class TestPresenterAutoSelectAllowed:
+    """Verify is_auto_select_allowed reflects binary mode."""
+
+    def test_auto_select_allowed_when_mode_off(self) -> None:
+        presenter, _, _ = make_presenter(binary_mode=False)
+        assert presenter.is_auto_select_allowed() is True
+
+    def test_auto_select_blocked_when_mode_on(self) -> None:
+        presenter, _, _ = make_presenter(binary_mode=True)
+        assert presenter.is_auto_select_allowed() is False
+
+    def test_auto_select_updates_after_toggle(self) -> None:
+        presenter, _, _ = make_presenter(binary_mode=False)
+        assert presenter.is_auto_select_allowed() is True
+        presenter.set_binary_mode(True)
+        assert presenter.is_auto_select_allowed() is False
+        presenter.set_binary_mode(False)
+        assert presenter.is_auto_select_allowed() is True
+
+
+class TestPresenterStartScanSnapshots:
+    """Verify that start_scan snapshots binary mode before spawning the worker."""
+
+    def test_mode_snapshot_at_scan_start(self, tmp_path: object) -> None:
+        """Toggle mode to True, start scan, then toggle to False before thread completes.
+        Worker must have been called with binary params (allowed_extensions is not None)."""
+        import os as _os
+        presenter, view, _ = make_presenter(binary_mode=True)
+
+        captured_kwargs: list[dict] = []
+
+        def fake_find_duplicates(*args: object, **kwargs: object) -> list:
+            captured_kwargs.append(kwargs)
+            return []
+
+        with patch("src.ui.presenters.duplicates_presenter.find_duplicates", fake_find_duplicates):
+            presenter.start_scan([str(tmp_path)])
+            # Toggle mode to False after scan started (simulating user action mid-scan)
+            presenter.set_binary_mode(False)
+            # Allow thread to complete
+            time.sleep(0.3)
+
+        assert len(captured_kwargs) == 1
+        # Worker must have used binary params (snapshot taken before toggle)
+        assert captured_kwargs[0].get("allowed_extensions") is not None
+        assert captured_kwargs[0].get("min_size_bytes") == 51_200

--- a/cleanacelerai/tests/test_config_service.py
+++ b/cleanacelerai/tests/test_config_service.py
@@ -131,3 +131,48 @@ class TestConfigServiceSave:
             result = service.load({})
 
         assert result["keywords"] == ["new"]
+
+
+class TestBinaryModeConfigKey:
+    """Verify binary_assets_mode_enabled key round-trips correctly."""
+
+    def test_binary_mode_persists_across_save_load(self, tmp_path: Path) -> None:
+        """Save True, reload — must return True."""
+        config_dir = tmp_path / ".cleanacelerai"
+        config_file = config_dir / "config.json"
+        payload = {"keywords": [], "folders": [], "binary_assets_mode_enabled": True}
+
+        service = ConfigService()
+        with (
+            patch("src.infrastructure.config_service.CONFIG_DIR", config_dir),
+            patch("src.infrastructure.config_service.CONFIG_FILE", config_file),
+        ):
+            service.save(payload)
+            result = service.load({"keywords": [], "folders": [], "binary_assets_mode_enabled": False})
+
+        assert result["binary_assets_mode_enabled"] is True
+
+    def test_binary_mode_defaults_to_false_on_fresh_install(self, tmp_path: Path) -> None:
+        """No config file: defaults must supply binary_assets_mode_enabled=False."""
+        config_file = tmp_path / "nonexistent.json"
+        defaults = {"keywords": [], "folders": [], "binary_assets_mode_enabled": False}
+
+        service = ConfigService()
+        with patch("src.infrastructure.config_service.CONFIG_FILE", config_file):
+            result = service.load(defaults)
+
+        assert result["binary_assets_mode_enabled"] is False
+
+    def test_binary_mode_defaults_to_false_on_old_config(self, tmp_path: Path) -> None:
+        """Old config without the key: defaults merge supplies False."""
+        config_file = tmp_path / "old_config.json"
+        # Old config has no binary_assets_mode_enabled key
+        config_file.write_text(json.dumps({"keywords": [".git"], "folders": []}), encoding="utf-8")
+        defaults = {"keywords": [], "folders": [], "binary_assets_mode_enabled": False}
+
+        service = ConfigService()
+        with patch("src.infrastructure.config_service.CONFIG_FILE", config_file):
+            result = service.load(defaults)
+
+        assert result["binary_assets_mode_enabled"] is False
+        assert result["keywords"] == [".git"]  # existing keys preserved

--- a/cleanacelerai/tests/test_duplicate_finder.py
+++ b/cleanacelerai/tests/test_duplicate_finder.py
@@ -6,6 +6,7 @@ from unittest.mock import patch
 
 import pytest
 
+from src.domain.constants import EXTENSIONES_ASSETS_BINARIOS
 from src.services.duplicate_finder import _hash_file, find_duplicates
 
 
@@ -44,7 +45,8 @@ class TestFindDuplicates:
         (tmp_path / "unique.bin").write_bytes(b"different" * 200)
 
         with patch("src.services.duplicate_finder.CARPETAS_SISTEMA", set()):
-            groups = find_duplicates([str(tmp_path)])
+            with patch("src.services.duplicate_finder.PATHS_BLOQUEADOS_SCAN", ()):
+                groups = find_duplicates([str(tmp_path)])
 
         assert len(groups) == 1
         assert len(groups[0].files) == 2
@@ -82,7 +84,8 @@ class TestFindDuplicates:
         (tmp_path / "copy3.bin").write_bytes(content)
 
         with patch("src.services.duplicate_finder.CARPETAS_SISTEMA", set()):
-            groups = find_duplicates([str(tmp_path)])
+            with patch("src.services.duplicate_finder.PATHS_BLOQUEADOS_SCAN", ()):
+                groups = find_duplicates([str(tmp_path)])
         assert len(groups) == 1
         assert len(groups[0].files) == 3
 
@@ -162,5 +165,132 @@ class TestBlocklistedPathsSkipped:
         with patch("src.services.duplicate_finder.PATHS_BLOQUEADOS_SCAN", blocked):
             with patch("src.services.duplicate_finder.CARPETAS_SISTEMA", set()):
                 groups = find_duplicates([str(tmp_path)])
+
+        assert len(groups) == 1
+
+
+class TestFindDuplicatesBackwardCompat:
+    """Verify that the new kwargs do not break existing behavior when omitted."""
+
+    def test_default_args_no_extension_filter(self, tmp_path: Path) -> None:
+        """Call without new kwargs: .py file > 1 KB is included (no extension filter)."""
+        content = b"python source" * 200  # > 1 KB
+        (tmp_path / "script1.py").write_bytes(content)
+        (tmp_path / "script2.py").write_bytes(content)
+
+        with patch("src.services.duplicate_finder.CARPETAS_SISTEMA", set()):
+            with patch("src.services.duplicate_finder.PATHS_BLOQUEADOS_SCAN", ()):
+                groups = find_duplicates([str(tmp_path)])
+
+        # allowed_extensions=None means no filter → .py files are candidates
+        assert len(groups) == 1
+        assert len(groups[0].files) == 2
+
+    def test_default_size_floor_is_1024_skips_at_boundary(self, tmp_path: Path) -> None:
+        """A file of exactly 1024 bytes must be skipped (size > 1024 is the gate)."""
+        content_1024 = b"x" * 1024
+        content_1025 = b"x" * 1025
+        (tmp_path / "small1.bin").write_bytes(content_1024)
+        (tmp_path / "small2.bin").write_bytes(content_1024)
+        (tmp_path / "larger1.bin").write_bytes(content_1025)
+        (tmp_path / "larger2.bin").write_bytes(content_1025)
+
+        with patch("src.services.duplicate_finder.CARPETAS_SISTEMA", set()):
+            with patch("src.services.duplicate_finder.PATHS_BLOQUEADOS_SCAN", ()):
+                groups = find_duplicates([str(tmp_path)])
+
+        # Only the 1025-byte pair should form a group
+        assert len(groups) == 1
+        assert all("larger" in f.path for f in groups[0].files)
+
+
+class TestFindDuplicatesBinaryMode:
+    """Verify behavior of the new blocked_paths, allowed_extensions, min_size_bytes kwargs."""
+
+    def test_py_file_skipped_with_whitelist(self, tmp_path: Path) -> None:
+        """A .py file is NOT returned when allowed_extensions=EXTENSIONES_ASSETS_BINARIOS."""
+        content = b"python source file" * 200
+        (tmp_path / "script1.py").write_bytes(content)
+        (tmp_path / "script2.py").write_bytes(content)
+
+        with patch("src.services.duplicate_finder.CARPETAS_SISTEMA", set()):
+            with patch("src.services.duplicate_finder.PATHS_BLOQUEADOS_SCAN", ()):
+                groups = find_duplicates(
+                    [str(tmp_path)],
+                    allowed_extensions=EXTENSIONES_ASSETS_BINARIOS,
+                )
+
+        assert groups == []
+
+    def test_30kb_png_skipped_with_size_floor(self, tmp_path: Path) -> None:
+        """A 30 KB .png is skipped when min_size_bytes=51200 (30720 <= 51200)."""
+        content = b"x" * 30_720  # 30 KB
+        (tmp_path / "img1.png").write_bytes(content)
+        (tmp_path / "img2.png").write_bytes(content)
+
+        with patch("src.services.duplicate_finder.CARPETAS_SISTEMA", set()):
+            with patch("src.services.duplicate_finder.PATHS_BLOQUEADOS_SCAN", ()):
+                groups = find_duplicates(
+                    [str(tmp_path)],
+                    allowed_extensions=EXTENSIONES_ASSETS_BINARIOS,
+                    min_size_bytes=51_200,
+                )
+
+        assert groups == []
+
+    def test_100kb_png_included_with_size_floor(self, tmp_path: Path) -> None:
+        """A 100 KB .png IS returned when min_size_bytes=51200 (102400 > 51200)."""
+        content = b"y" * 102_400  # 100 KB
+        (tmp_path / "big1.png").write_bytes(content)
+        (tmp_path / "big2.png").write_bytes(content)
+
+        with patch("src.services.duplicate_finder.CARPETAS_SISTEMA", set()):
+            with patch("src.services.duplicate_finder.PATHS_BLOQUEADOS_SCAN", ()):
+                groups = find_duplicates(
+                    [str(tmp_path)],
+                    allowed_extensions=EXTENSIONES_ASSETS_BINARIOS,
+                    min_size_bytes=51_200,
+                )
+
+        assert len(groups) == 1
+        assert len(groups[0].files) == 2
+
+    def test_blocked_paths_override(self, tmp_path: Path) -> None:
+        """blocked_paths kwarg overrides the default blocklist for that call."""
+        safe_dir = tmp_path / "safe"
+        blocked_dir = tmp_path / "node_modules"
+        safe_dir.mkdir()
+        blocked_dir.mkdir()
+
+        content = b"z" * 2000
+        (tmp_path / "orig.bin").write_bytes(content)
+        (safe_dir / "copy_safe.bin").write_bytes(content)
+        (blocked_dir / "copy_blocked.bin").write_bytes(content)
+
+        import os as _os
+        custom_blocked = (_os.sep + "node_modules" + _os.sep,)
+        with patch("src.services.duplicate_finder.CARPETAS_SISTEMA", set()):
+            groups = find_duplicates(
+                [str(tmp_path)],
+                blocked_paths=custom_blocked,
+            )
+
+        # blocked_dir copy is skipped; orig + safe_dir copy remain → 1 group of 2
+        assert len(groups) == 1
+        assert len(groups[0].files) == 2
+        assert all("node_modules" not in f.path for f in groups[0].files)
+
+    def test_no_extension_filter_when_none(self, tmp_path: Path) -> None:
+        """allowed_extensions=None (default) does not filter by extension."""
+        content = b"mix" * 500
+        (tmp_path / "file1.bin").write_bytes(content)
+        (tmp_path / "file2.bin").write_bytes(content)
+
+        with patch("src.services.duplicate_finder.CARPETAS_SISTEMA", set()):
+            with patch("src.services.duplicate_finder.PATHS_BLOQUEADOS_SCAN", ()):
+                groups = find_duplicates(
+                    [str(tmp_path)],
+                    allowed_extensions=None,
+                )
 
         assert len(groups) == 1

--- a/cleanacelerai/tests/test_path_blocklist.py
+++ b/cleanacelerai/tests/test_path_blocklist.py
@@ -3,7 +3,13 @@ from __future__ import annotations
 
 import pytest
 
-from src.domain.constants import PATHS_BLOQUEADOS_SCAN
+from src.domain.constants import (
+    BINARY_MODE_SIZE_FLOOR_BYTES,
+    EXTENSIONES_ASSETS_BINARIOS,
+    PATHS_BLOQUEADOS_SCAN,
+    PATHS_BLOQUEADOS_SCAN_PROJECTS,
+    PATHS_BLOQUEADOS_SCAN_TECH,
+)
 from src.ui.presenters.duplicates_presenter import DuplicatesPresenter
 
 
@@ -102,3 +108,96 @@ class TestPresenterIsPathBlocked:
     def test_venv_parent_exact_is_blocked(self) -> None:
         p = make_presenter()
         assert p.is_path_blocked(r"D:\projects\myapp\venv")
+
+
+class TestBlocklistSplit:
+    """Verify PATHS_BLOQUEADOS_SCAN_TECH + PATHS_BLOQUEADOS_SCAN_PROJECTS split."""
+
+    def test_alias_equals_union(self) -> None:
+        assert PATHS_BLOQUEADOS_SCAN == PATHS_BLOQUEADOS_SCAN_TECH + PATHS_BLOQUEADOS_SCAN_PROJECTS
+
+    def test_appdata_broad_in_tech(self) -> None:
+        assert "\\AppData\\" in PATHS_BLOQUEADOS_SCAN_TECH
+
+    def test_appdata_roaming_local_absent_from_tech(self) -> None:
+        assert "\\AppData\\Roaming\\Local\\" not in PATHS_BLOQUEADOS_SCAN_TECH
+
+    def test_appdata_roaming_local_absent_from_projects(self) -> None:
+        assert "\\AppData\\Roaming\\Local\\" not in PATHS_BLOQUEADOS_SCAN_PROJECTS
+
+    def test_appdata_roaming_local_absent_from_alias(self) -> None:
+        assert "\\AppData\\Roaming\\Local\\" not in PATHS_BLOQUEADOS_SCAN
+
+    def test_mis_proyectos_in_projects(self) -> None:
+        assert "\\Mis_proyectos\\" in PATHS_BLOQUEADOS_SCAN_PROJECTS
+
+    def test_local_sites_in_projects(self) -> None:
+        assert "\\Local Sites\\" in PATHS_BLOQUEADOS_SCAN_PROJECTS
+
+    def test_node_modules_in_tech(self) -> None:
+        assert "\\node_modules\\" in PATHS_BLOQUEADOS_SCAN_TECH
+
+    def test_legacy_alias_still_has_9_entries(self) -> None:
+        assert len(PATHS_BLOQUEADOS_SCAN) == 9
+
+
+class TestExtensionWhitelistConstant:
+    """Verify EXTENSIONES_ASSETS_BINARIOS contains expected and excludes forbidden."""
+
+    def test_whitelist_contains_png(self) -> None:
+        assert ".png" in EXTENSIONES_ASSETS_BINARIOS
+
+    def test_whitelist_contains_jpg(self) -> None:
+        assert ".jpg" in EXTENSIONES_ASSETS_BINARIOS
+
+    def test_whitelist_contains_jpeg(self) -> None:
+        assert ".jpeg" in EXTENSIONES_ASSETS_BINARIOS
+
+    def test_whitelist_contains_gif(self) -> None:
+        assert ".gif" in EXTENSIONES_ASSETS_BINARIOS
+
+    def test_whitelist_contains_webp(self) -> None:
+        assert ".webp" in EXTENSIONES_ASSETS_BINARIOS
+
+    def test_whitelist_contains_pdf(self) -> None:
+        assert ".pdf" in EXTENSIONES_ASSETS_BINARIOS
+
+    def test_whitelist_contains_mp4(self) -> None:
+        assert ".mp4" in EXTENSIONES_ASSETS_BINARIOS
+
+    def test_whitelist_contains_mov(self) -> None:
+        assert ".mov" in EXTENSIONES_ASSETS_BINARIOS
+
+    def test_whitelist_contains_mp3(self) -> None:
+        assert ".mp3" in EXTENSIONES_ASSETS_BINARIOS
+
+    def test_whitelist_contains_zip(self) -> None:
+        assert ".zip" in EXTENSIONES_ASSETS_BINARIOS
+
+    def test_whitelist_contains_psd(self) -> None:
+        assert ".psd" in EXTENSIONES_ASSETS_BINARIOS
+
+    def test_whitelist_contains_fig(self) -> None:
+        assert ".fig" in EXTENSIONES_ASSETS_BINARIOS
+
+    def test_whitelist_excludes_py(self) -> None:
+        assert ".py" not in EXTENSIONES_ASSETS_BINARIOS
+
+    def test_whitelist_excludes_js(self) -> None:
+        assert ".js" not in EXTENSIONES_ASSETS_BINARIOS
+
+    def test_whitelist_excludes_php(self) -> None:
+        assert ".php" not in EXTENSIONES_ASSETS_BINARIOS
+
+    def test_whitelist_excludes_json(self) -> None:
+        assert ".json" not in EXTENSIONES_ASSETS_BINARIOS
+
+    def test_whitelist_excludes_md(self) -> None:
+        assert ".md" not in EXTENSIONES_ASSETS_BINARIOS
+
+
+class TestBinaryModeSizeFloor:
+    """Verify BINARY_MODE_SIZE_FLOOR_BYTES constant."""
+
+    def test_size_floor_value(self) -> None:
+        assert BINARY_MODE_SIZE_FLOOR_BYTES == 51_200


### PR DESCRIPTION
## Summary

Opt-in "Modo Assets Binarios" toggle for the Duplicados IA module. Lets the user scan `\Mis_proyectos\` and `\Local Sites\` for duplicate **binary assets** (images, videos, PDFs, archives, design files) WITHOUT exposing code files to deletion.

**Tech folders stay always-blocked** in this mode (`\.git\`, `\node_modules\`, `\venv\`, `\dist\`, `\build\`, `\AppData\`). The `\AppData\` entry is broadened from the previous imprecise `\AppData\Roaming\Local\`.

## Changes

- **domain/constants.py**: split `PATHS_BLOQUEADOS_SCAN` into `_TECH` (always blocked) and `_PROJECTS` (unlocked in binary mode). Backward-compat alias preserved. New `EXTENSIONES_ASSETS_BINARIOS` whitelist and `BINARY_MODE_SIZE_FLOOR_BYTES = 51200` (50 KB).
- **services/duplicate_finder.py**: new keyword-only args `blocked_paths`, `allowed_extensions`, `min_size_bytes`. Resolved at call time, not signature default — keeps `unittest.mock.patch` working for existing tests.
- **infrastructure/config_service.py**: `binary_assets_mode_enabled: False` in defaults — persists across app restart.
- **ui/presenters/duplicates_presenter.py**: `_binary_mode` state, `set_binary_mode()` with try/except + `view.show_error`, mode-aware `is_path_blocked()`, `is_auto_select_allowed()`, mode snapshot at `start_scan` time.
- **ui/views/duplicates_view.py**: amber `COLOR_WARNING` banner above the explanation card (visible only when mode ON), checkbox above paths listbox, Auto-Select disabled when mode ON, extra pre-scan confirmation dialog, stronger delete confirmation.
- **ui/main_window.py**: initial mode loaded from config + passed to view/presenter, re-sync on `_select_frame("duplicados")` navigation.

## Safety properties

- `send2trash` remains the only delete path (no `os.remove` regressions)
- `EXTENSIONES_CODIGO_PROTEGIDAS` still applies as defense-in-depth at the risk evaluator level
- Auto-Select **disabled** when mode is ON — user must hand-pick which copy survives per group
- Mandatory amber banner makes the active state impossible to miss
- Mode change mid-scan does NOT affect the running scan (worker captures params at start)

## Test plan

- [x] `pytest cleanacelerai/tests/` — 190/190 pass (135 baseline + 55 new)
- [x] Manual: mode OFF, `D:\Mis_proyectos` is refused (existing PR #33 behavior preserved)
- [x] Manual: toggle mode ON → amber banner appears, Auto-Select greys out
- [x] Manual: mode ON, `D:\Mis_proyectos` enters listbox
- [x] Manual: mode ON, click Iniciar → extra confirmation dialog fires
- [x] Manual: close + reopen app → checkbox state persists
- [ ] Optional smoke: actual scan in mode ON on a folder with duplicate PSDs/PNGs

Built via SDD cycle (proposal → spec → design → tasks → apply → verify → archive). All artifacts persisted to engram.
