### PR TITLE
feat: Asesor de Orden uses send2trash + project-signature dialog

### DIFF
--- a/cleanacelerai/src/domain/constants.py
+++ b/cleanacelerai/src/domain/constants.py
@@ -106,3 +106,35 @@ SYSTEM_ROOT_PROTECTED: set[str] = {
     "system volume information", "boot",
     "documents and settings",
 }
+
+# --- Project-signature signals (Asesor Safe Delete) ---
+PROJECT_SIGNAL_INSIDE_MIS_PROYECTOS = "inside-mis-proyectos"
+PROJECT_SIGNAL_INSIDE_LOCAL_SITES   = "inside-local-sites"
+PROJECT_SIGNAL_HAS_GIT              = "has-git"
+PROJECT_SIGNAL_HAS_PACKAGE_JSON     = "has-package-json"
+PROJECT_SIGNAL_HAS_COMPOSER_JSON    = "has-composer-json"
+PROJECT_SIGNAL_HAS_PYPROJECT_TOML   = "has-pyproject-toml"
+PROJECT_SIGNAL_HAS_CARGO_TOML       = "has-cargo-toml"
+PROJECT_SIGNAL_HAS_GO_MOD           = "has-go-mod"
+PROJECT_SIGNAL_HAS_POM_XML          = "has-pom-xml"
+PROJECT_SIGNAL_HAS_SOLUTION_FILE    = "has-solution-file"
+PROJECT_SIGNAL_HAS_CSPROJ           = "has-csproj"
+PROJECT_SIGNAL_HAS_WP_CONFIG        = "has-wp-config"
+PROJECT_SIGNAL_HAS_GEMFILE          = "has-gemfile"
+
+# Human-readable labels for the confirm dialog. View imports this map.
+PROJECT_SIGNAL_LABELS: dict[str, str] = {
+    PROJECT_SIGNAL_INSIDE_MIS_PROYECTOS: "Esta dentro de Mis_proyectos",
+    PROJECT_SIGNAL_INSIDE_LOCAL_SITES:   "Esta dentro de Local Sites",
+    PROJECT_SIGNAL_HAS_GIT:              "Contiene .git",
+    PROJECT_SIGNAL_HAS_PACKAGE_JSON:     "Contiene package.json",
+    PROJECT_SIGNAL_HAS_COMPOSER_JSON:    "Contiene composer.json",
+    PROJECT_SIGNAL_HAS_PYPROJECT_TOML:   "Contiene pyproject.toml",
+    PROJECT_SIGNAL_HAS_CARGO_TOML:       "Contiene Cargo.toml",
+    PROJECT_SIGNAL_HAS_GO_MOD:           "Contiene go.mod",
+    PROJECT_SIGNAL_HAS_POM_XML:          "Contiene pom.xml",
+    PROJECT_SIGNAL_HAS_SOLUTION_FILE:    "Contiene un .sln",
+    PROJECT_SIGNAL_HAS_CSPROJ:           "Contiene un .csproj",
+    PROJECT_SIGNAL_HAS_WP_CONFIG:        "Contiene wp-config.php",
+    PROJECT_SIGNAL_HAS_GEMFILE:          "Contiene Gemfile",
+}

--- a/cleanacelerai/src/domain/models.py
+++ b/cleanacelerai/src/domain/models.py
@@ -172,3 +172,16 @@ class DeepCleanResult:
     total_scanned: int
     total_recoverable_bytes: int
     scan_errors: list[str]
+
+
+# --- Asesor Safe Delete ---
+
+@dataclass(frozen=True)
+class ProjectSignature:
+    """A folder that exhibits one or more 'this is a real project' signals.
+
+    Immutable value object: detector output must not be mutated by presenter or view.
+    """
+    path: str
+    signals: tuple[str, ...]  # canonical PROJECT_SIGNAL_* values
+    last_modified_days: int | None

--- a/cleanacelerai/src/infrastructure/file_system.py
+++ b/cleanacelerai/src/infrastructure/file_system.py
@@ -9,15 +9,22 @@ import stat
 import subprocess
 from pathlib import Path
 
-from send2trash import send2trash
+from send2trash import TrashPermissionError, send2trash
 
 
-def _log_deletion(file_path: str) -> None:
+def _log_deletion(
+    file_path: str,
+    source: str | None = None,
+    fallback_rename: bool = False,
+) -> None:
     """
     Append a JSON record to ~/.cleanacelerai/deleted.log before every deletion.
 
     Args:
         file_path: Absolute path of the file about to be deleted.
+        source: Optional source tag (e.g. 'asesor.orden-general'). When None,
+                the key is omitted entirely to preserve backward-compatible log shape.
+        fallback_rename: When True, adds 'fallback_rename': true to the log entry.
     """
     log_dir = Path.home() / '.cleanacelerai'
     log_dir.mkdir(exist_ok=True)
@@ -31,12 +38,18 @@ def _log_deletion(file_path: str) -> None:
             file_hash = hashlib.sha256(f.read(65536)).hexdigest()[:16]
     except OSError:
         file_hash = 'unreadable'
-    entry = {
+    entry: dict[str, object] = {
         'ts': datetime.datetime.now().isoformat(timespec='seconds'),
         'path': str(file_path),
         'size': size,
         'sha256_first_64k': file_hash,
     }
+    # Only write optional fields when set, preserving existing log shape for
+    # callers that pass no source (safe_delete for files).
+    if source is not None:
+        entry['source'] = source
+    if fallback_rename:
+        entry['fallback_rename'] = True
     with log_path.open('a', encoding='utf-8') as f:
         f.write(json.dumps(entry, ensure_ascii=False) + '\n')
 
@@ -81,6 +94,54 @@ def safe_delete(path: str) -> tuple[bool, str]:
         return False, f"Permiso denegado: {e}"
     except FileNotFoundError:
         return True, ""  # Already deleted — treat as success
+    except OSError as e:
+        return False, str(e)
+
+
+def safe_delete_dir(path: str, source: str = "asesor") -> tuple[bool, str]:
+    """Delete a directory safely by sending it to the Recycle Bin.
+
+    On TrashPermissionError (typically a non-C: drive where the shell refuses
+    to recycle): fallback to in-place rename
+        '{name}.UNSAFE-CANT-RECYCLE.{ISO-timestamp}.bak'
+    The caller (presenter) is responsible for surfacing the fallback to the user
+    via a view widget — this function only returns success=True and the rename
+    is recorded in the deletion log with fallback_rename=True.
+
+    Args:
+        path: Absolute path to the directory to delete.
+        source: Source tag for the audit log (e.g. 'asesor.orden-general').
+
+    Returns:
+        (True, '') on clean Recycle Bin success.
+        (True, 'FALLBACK_RENAME:{new_path}') on fallback rename success.
+        (False, error_msg) on hard failure.
+    """
+    if not os.path.isdir(path):
+        return False, f"No es un directorio: {path}"
+
+    try:
+        _log_deletion(path, source=source, fallback_rename=False)
+        send2trash(str(path))
+        return True, ""
+    except TrashPermissionError:
+        # Drive does not allow Recycle Bin (e.g., D: on some configs).
+        # Rename in-place so the data survives.
+        try:
+            parent = os.path.dirname(path)
+            base = os.path.basename(path)
+            ts = datetime.datetime.now().strftime("%Y%m%dT%H%M%S")
+            new_name = f"{base}.UNSAFE-CANT-RECYCLE.{ts}.bak"
+            new_path = os.path.join(parent, new_name)
+            os.rename(path, new_path)
+            _log_deletion(new_path, source=source, fallback_rename=True)
+            return True, f"FALLBACK_RENAME:{new_path}"
+        except OSError as e:
+            return False, f"No se pudo eliminar ni renombrar: {e}"
+    except PermissionError as e:
+        return False, f"Permiso denegado: {e}"
+    except FileNotFoundError:
+        return True, ""  # Already gone
     except OSError as e:
         return False, str(e)
 

--- a/cleanacelerai/src/services/project_detector.py
+++ b/cleanacelerai/src/services/project_detector.py
@@ -1,0 +1,138 @@
+"""Service: detect whether a folder looks like a live project."""
+from __future__ import annotations
+
+import os
+import time
+
+from ..domain.constants import (
+    PATHS_BLOQUEADOS_SCAN_PROJECTS,
+    PROJECT_SIGNAL_HAS_CARGO_TOML,
+    PROJECT_SIGNAL_HAS_COMPOSER_JSON,
+    PROJECT_SIGNAL_HAS_CSPROJ,
+    PROJECT_SIGNAL_HAS_GEMFILE,
+    PROJECT_SIGNAL_HAS_GIT,
+    PROJECT_SIGNAL_HAS_GO_MOD,
+    PROJECT_SIGNAL_HAS_PACKAGE_JSON,
+    PROJECT_SIGNAL_HAS_POM_XML,
+    PROJECT_SIGNAL_HAS_PYPROJECT_TOML,
+    PROJECT_SIGNAL_HAS_SOLUTION_FILE,
+    PROJECT_SIGNAL_HAS_WP_CONFIG,
+    PROJECT_SIGNAL_INSIDE_LOCAL_SITES,
+    PROJECT_SIGNAL_INSIDE_MIS_PROYECTOS,
+)
+from ..domain.models import ProjectSignature
+
+
+# Exact-name matches (lowercased). dir/file flag tells the detector
+# how to verify the entry.
+# Tuple format: (signal_constant, expected_name_lower, is_dir)
+_NAME_SIGNALS: tuple[tuple[str, str, bool], ...] = (
+    (PROJECT_SIGNAL_HAS_GIT,            ".git",            True),
+    (PROJECT_SIGNAL_HAS_PACKAGE_JSON,   "package.json",    False),
+    (PROJECT_SIGNAL_HAS_COMPOSER_JSON,  "composer.json",   False),
+    (PROJECT_SIGNAL_HAS_PYPROJECT_TOML, "pyproject.toml",  False),
+    (PROJECT_SIGNAL_HAS_CARGO_TOML,     "cargo.toml",      False),
+    (PROJECT_SIGNAL_HAS_GO_MOD,         "go.mod",          False),
+    (PROJECT_SIGNAL_HAS_POM_XML,        "pom.xml",         False),
+    (PROJECT_SIGNAL_HAS_WP_CONFIG,      "wp-config.php",   False),
+    (PROJECT_SIGNAL_HAS_GEMFILE,        "gemfile",         False),
+)
+
+
+def detect_project_signature(path: str) -> ProjectSignature | None:
+    """Return a ProjectSignature if the folder looks like a project, else None.
+
+    Pure-ish: only reads metadata of `path` itself + direct children (no recursive walk).
+    Never raises; on any unexpected error returns None so the caller treats the folder
+    as "not a project" (and the deletion still goes through safe_delete_dir).
+
+    Symlinks are NOT followed: if `path` is a symlink we return None.
+    """
+    if not path or not os.path.isdir(path):
+        return None
+    if os.path.islink(path):
+        return None
+
+    signals: list[str] = []
+
+    # Path-based signals: uses normpath().lower() + os.sep trick consistent
+    # with DuplicatesPresenter.is_path_blocked.
+    path_norm = os.path.normpath(path).lower() + os.sep
+    for marker in PATHS_BLOQUEADOS_SCAN_PROJECTS:
+        marker_l = marker.lower()
+        if marker_l in path_norm:
+            if "mis_proyectos" in marker_l:
+                signals.append(PROJECT_SIGNAL_INSIDE_MIS_PROYECTOS)
+            elif "local sites" in marker_l:
+                signals.append(PROJECT_SIGNAL_INSIDE_LOCAL_SITES)
+
+    # Direct-children scan (single os.listdir, no recursion)
+    try:
+        children = os.listdir(path)
+    except (PermissionError, OSError):
+        # If we cannot list, we cannot detect file-based signals.
+        # If path-based signals already found something, still return them.
+        if signals:
+            return ProjectSignature(
+                path=path,
+                signals=tuple(signals),
+                last_modified_days=None,
+            )
+        return None
+
+    children_lower = {c.lower(): c for c in children}
+
+    for signal, name_lower, is_dir in _NAME_SIGNALS:
+        original = children_lower.get(name_lower)
+        if original is None:
+            continue
+        full = os.path.join(path, original)
+        try:
+            if is_dir and os.path.isdir(full):
+                signals.append(signal)
+            elif (not is_dir) and os.path.isfile(full):
+                signals.append(signal)
+        except OSError:
+            pass
+
+    # Glob-style signals using the same listing (no second os.listdir)
+    for name in children:
+        if name.lower().endswith(".sln"):
+            signals.append(PROJECT_SIGNAL_HAS_SOLUTION_FILE)
+            break
+    for name in children:
+        if name.lower().endswith(".csproj"):
+            signals.append(PROJECT_SIGNAL_HAS_CSPROJ)
+            break
+
+    if not signals:
+        return None
+
+    last_modified_days = _max_child_age_days(path, children)
+
+    return ProjectSignature(
+        path=path,
+        signals=tuple(signals),
+        last_modified_days=last_modified_days,
+    )
+
+
+def _max_child_age_days(path: str, children: list[str]) -> int | None:
+    """Return the age (in days) of the most-recently-modified top-level child.
+
+    Returns None if the folder is empty or all children are unreadable.
+    """
+    now = time.time()
+    most_recent: float | None = None
+    for name in children:
+        full = os.path.join(path, name)
+        try:
+            mtime = os.path.getmtime(full)
+        except OSError:
+            continue
+        if most_recent is None or mtime > most_recent:
+            most_recent = mtime
+    if most_recent is None:
+        return None
+    delta_seconds = max(0.0, now - most_recent)
+    return int(delta_seconds // 86400)

--- a/cleanacelerai/src/services/project_detector.py
+++ b/cleanacelerai/src/services/project_detector.py
@@ -5,7 +5,6 @@ import os
 import time
 
 from ..domain.constants import (
-    PATHS_BLOQUEADOS_SCAN_PROJECTS,
     PROJECT_SIGNAL_HAS_CARGO_TOML,
     PROJECT_SIGNAL_HAS_COMPOSER_JSON,
     PROJECT_SIGNAL_HAS_CSPROJ,
@@ -21,6 +20,15 @@ from ..domain.constants import (
     PROJECT_SIGNAL_INSIDE_MIS_PROYECTOS,
 )
 from ..domain.models import ProjectSignature
+
+
+# Inlined path markers — kept independent of the Duplicados IA blocklist
+# split so this service can ship without dependencies on that module's
+# constant layout.
+_PROJECT_PATH_MARKERS: tuple[str, ...] = (
+    "\\Local Sites\\",
+    "\\Mis_proyectos\\",
+)
 
 
 # Exact-name matches (lowercased). dir/file flag tells the detector
@@ -58,7 +66,7 @@ def detect_project_signature(path: str) -> ProjectSignature | None:
     # Path-based signals: uses normpath().lower() + os.sep trick consistent
     # with DuplicatesPresenter.is_path_blocked.
     path_norm = os.path.normpath(path).lower() + os.sep
-    for marker in PATHS_BLOQUEADOS_SCAN_PROJECTS:
+    for marker in _PROJECT_PATH_MARKERS:
         marker_l = marker.lower()
         if marker_l in path_norm:
             if "mis_proyectos" in marker_l:

--- a/cleanacelerai/src/ui/presenters/asesor_presenter.py
+++ b/cleanacelerai/src/ui/presenters/asesor_presenter.py
@@ -223,10 +223,10 @@ class AsesorPresenter:
                 f"(la unidad lo prohibe). Se renombraron en su lugar:\n\n{rename_lines}\n\n"
                 "Borralas manualmente cuando quieras.",
             )
-        elif state["errores"]:
-            msg += f"\n\n{len(state['errores'])} error(es):\n" + "\n".join(state["errores"])
-            self.view.show_warning("Borrar — con errores", msg)
-        else:
+        if state["errores"]:
+            error_msg = msg + f"\n\n{len(state['errores'])} error(es):\n" + "\n".join(state["errores"])
+            self.view.show_warning("Borrar — con errores", error_msg)
+        elif not state["fallbacks"]:
             self.view.show_info("Borrar — completado", msg)
 
     def explain(self, nombre: str, tipo: str) -> str:

--- a/cleanacelerai/src/ui/presenters/asesor_presenter.py
+++ b/cleanacelerai/src/ui/presenters/asesor_presenter.py
@@ -14,8 +14,9 @@ from ...domain.models import (
     DeepCleanRisk,
     DocumentAnalysisResult,
 )
-from ...infrastructure.file_system import safe_delete
+from ...infrastructure.file_system import safe_delete, safe_delete_dir
 from ...services.chaos_advisor import analyze_folder, explain_element
+from ...services.project_detector import detect_project_signature
 
 if TYPE_CHECKING:
     from ..views.asesor_view import AsesorView
@@ -71,55 +72,159 @@ class AsesorPresenter:
         self.view.show_entries(entries)
 
     def move_items(self, items: list[tuple[str, str, str]], destino: str) -> None:
-        """Move the given (item_id, ruta, nombre) tuples to *destino* folder."""
-        movidos = 0
-        errores: list[str] = []
+        """Move the given (item_id, ruta, nombre) tuples to *destino* folder.
 
-        for item_id, ruta, nombre in items:
-            try:
-                shutil.move(ruta, destino)
-                movidos += 1
-                self.view.remove_item(item_id)
-            except shutil.Error as e:
-                errores.append(f"{nombre}: {e}")
-            except PermissionError as e:
-                errores.append(f"{nombre}: Permiso denegado — {e}")
-            except OSError as e:
-                errores.append(f"{nombre}: {e}")
+        Folders that carry a project signature surface a WARNING dialog before
+        proceeding. Non-project items are moved directly.
+        """
+        state: dict = {
+            "queue": list(items),
+            "destino": destino,
+            "movidos": 0,
+            "errores": [],
+        }
+        self._drain_move_queue(state)
 
-        msg = f"{movidos} elemento(s) movido(s) a:\n{destino}"
-        if errores:
-            msg += f"\n\n{len(errores)} error(es):\n" + "\n".join(errores)
+    def _drain_move_queue(self, state: dict) -> None:
+        """Process the move queue until empty or a project dialog yields control."""
+        while state["queue"]:
+            item_id, ruta, nombre = state["queue"][0]
+            if os.path.isdir(ruta):
+                sig = detect_project_signature(ruta)
+                if sig is not None:
+                    def _cb(
+                        confirmed: bool,
+                        item_id: str = item_id,
+                        ruta: str = ruta,
+                        nombre: str = nombre,
+                        state: dict = state,
+                    ) -> None:
+                        state["queue"].pop(0)
+                        if confirmed:
+                            self._execute_move(item_id, ruta, nombre, state)
+                        self._drain_move_queue(state)
+
+                    self.view.show_project_move_warning_dialog(sig, _cb)
+                    return  # wait for callback
+            state["queue"].pop(0)
+            self._execute_move(item_id, ruta, nombre, state)
+        self._finish_move_summary(state)
+
+    def _execute_move(self, item_id: str, ruta: str, nombre: str, state: dict) -> None:
+        try:
+            shutil.move(ruta, state["destino"])
+            state["movidos"] += 1
+            self.view.remove_item(item_id)
+        except shutil.Error as e:
+            state["errores"].append(f"{nombre}: {e}")
+        except PermissionError as e:
+            state["errores"].append(f"{nombre}: Permiso denegado — {e}")
+        except OSError as e:
+            state["errores"].append(f"{nombre}: {e}")
+
+    def _finish_move_summary(self, state: dict) -> None:
+        destino = state["destino"]
+        msg = f"{state['movidos']} elemento(s) movido(s) a:\n{destino}"
+        if state["errores"]:
+            msg += f"\n\n{len(state['errores'])} error(es):\n" + "\n".join(state["errores"])
             self.view.show_warning("Mover — con errores", msg)
         else:
             self.view.show_info("Mover — completado", msg)
 
     def delete_items(self, items: list[tuple[str, str, str]]) -> None:
-        """Delete the given (item_id, ruta, nombre) tuples."""
-        borrados = 0
-        errores: list[str] = []
+        """Delete the given (item_id, ruta, nombre) tuples.
 
-        for item_id, ruta, nombre in items:
+        Folders without a project signature are sent to the Recycle Bin via
+        safe_delete_dir. Folders with a project signature require the user to
+        type the folder name before deletion proceeds (type-to-confirm dialog).
+        Files continue to use the existing safe_delete path.
+        """
+        state: dict = {
+            "queue": list(items),
+            "borrados": 0,
+            "errores": [],
+            "fallbacks": [],
+        }
+        self._drain_delete_queue(state, source="asesor.orden-general")
+
+    def _drain_delete_queue(self, state: dict, source: str) -> None:
+        """Process the delete queue until empty or a project dialog yields control."""
+        while state["queue"]:
+            item_id, ruta, nombre = state["queue"][0]
             if os.path.isdir(ruta):
-                try:
-                    shutil.rmtree(ruta)
-                    borrados += 1
-                    self.view.remove_item(item_id)
-                except PermissionError as e:
-                    errores.append(f"{nombre}: Permiso denegado — {e}")
-                except OSError as e:
-                    errores.append(f"{nombre}: {e}")
-            else:
-                ok, error = safe_delete(ruta)
-                if ok:
-                    borrados += 1
-                    self.view.remove_item(item_id)
-                else:
-                    errores.append(f"{nombre}: {error}")
+                signature = detect_project_signature(ruta)
+                if signature is not None:
+                    def _cb(
+                        confirmed: bool,
+                        item_id: str = item_id,
+                        ruta: str = ruta,
+                        nombre: str = nombre,
+                        state: dict = state,
+                        source: str = source,
+                    ) -> None:
+                        state["queue"].pop(0)
+                        if confirmed:
+                            self._execute_dir_delete(item_id, ruta, nombre, source, state)
+                        # on cancel: silent skip, no log, no error row (spec rule)
+                        self._drain_delete_queue(state, source=source)
 
-        msg = f"{borrados} elemento(s) eliminado(s)."
-        if errores:
-            msg += f"\n\n{len(errores)} error(es):\n" + "\n".join(errores)
+                    self.view.show_project_confirm_dialog(signature, _cb)
+                    return  # wait for callback
+                # Plain directory — no project signature
+                state["queue"].pop(0)
+                self._execute_dir_delete(item_id, ruta, nombre, source, state)
+            else:
+                state["queue"].pop(0)
+                self._execute_file_delete(item_id, ruta, nombre, state)
+        # Queue drained
+        self._finish_delete_summary(state)
+
+    def _execute_dir_delete(
+        self,
+        item_id: str,
+        ruta: str,
+        nombre: str,
+        source: str,
+        state: dict,
+    ) -> None:
+        ok, error = safe_delete_dir(ruta, source=source)
+        if ok:
+            state["borrados"] += 1
+            self.view.remove_item(item_id)
+            if error.startswith("FALLBACK_RENAME:"):
+                new_path = error.split(":", 1)[1]
+                state["fallbacks"].append((nombre, new_path))
+        else:
+            state["errores"].append(f"{nombre}: {error}")
+
+    def _execute_file_delete(
+        self,
+        item_id: str,
+        ruta: str,
+        nombre: str,
+        state: dict,
+    ) -> None:
+        ok, error = safe_delete(ruta)
+        if ok:
+            state["borrados"] += 1
+            self.view.remove_item(item_id)
+        else:
+            state["errores"].append(f"{nombre}: {error}")
+
+    def _finish_delete_summary(self, state: dict) -> None:
+        msg = f"{state['borrados']} elemento(s) eliminado(s)."
+        if state["fallbacks"]:
+            rename_lines = "\n".join(
+                f"  - {n} -> {p}" for n, p in state["fallbacks"]
+            )
+            self.view.show_warning(
+                "Borrar — fallback en uso",
+                f"{len(state['fallbacks'])} carpeta(s) NO fueron al Reciclaje "
+                f"(la unidad lo prohibe). Se renombraron en su lugar:\n\n{rename_lines}\n\n"
+                "Borralas manualmente cuando quieras.",
+            )
+        elif state["errores"]:
+            msg += f"\n\n{len(state['errores'])} error(es):\n" + "\n".join(state["errores"])
             self.view.show_warning("Borrar — con errores", msg)
         else:
             self.view.show_info("Borrar — completado", msg)
@@ -382,21 +487,23 @@ class AsesorPresenter:
             ):
                 return
 
-        # Execute deletion
-        try:
-            shutil.rmtree(path)
+        # Execute deletion via safe_delete_dir (no shutil.rmtree — invariant I1)
+        ok, error = safe_delete_dir(path, source="asesor.limpieza-profunda")
+        if ok:
             self._deep_entries = [e for e in self._deep_entries if e.path != path]
             self.view.remove_deep_entry(path)
-            self.view.show_info("Eliminado", f"'{entry.name}' eliminado correctamente.")
+            if error.startswith("FALLBACK_RENAME:"):
+                new_path = error.split(":", 1)[1]
+                self.view.show_warning(
+                    "Renombrado (no fue al Reciclaje)",
+                    f"'{entry.name}' NO pudo ir al Reciclaje. Se renombro a:\n{new_path}\n\n"
+                    "Borrala manualmente cuando quieras.",
+                )
+            else:
+                self.view.show_info("Eliminado", f"'{entry.name}' eliminado correctamente.")
             self._update_recoverable_total()
-        except PermissionError:
-            self.view.show_error(
-                "Error",
-                f"Permiso denegado para eliminar '{entry.name}'.\n"
-                "Cerra los programas que la usen e intenta de nuevo.",
-            )
-        except OSError as e:
-            self.view.show_error("Error", f"No se pudo eliminar '{entry.name}':\n{e}")
+        else:
+            self.view.show_error("Error", f"No se pudo eliminar '{entry.name}':\n{error}")
 
     def bulk_delete_safe(self) -> None:
         """Delete all CACHE + EMPTY entries."""
@@ -435,13 +542,15 @@ class AsesorPresenter:
         errors: list[str] = []
 
         for entry in safe_entries:
-            try:
-                shutil.rmtree(entry.path)
+            ok, error = safe_delete_dir(entry.path, source="asesor.bulk-safe")
+            if ok:
                 self.view.remove_deep_entry(entry.path)
                 deleted_paths.add(entry.path)
                 deleted += 1
-            except (PermissionError, OSError) as e:
-                errors.append(f"{entry.name}: {e}")
+                if error.startswith("FALLBACK_RENAME:"):
+                    errors.append(f"{entry.name}: renombrado (no fue al Reciclaje)")
+            else:
+                errors.append(f"{entry.name}: {error}")
 
         self._deep_entries = [
             e for e in self._deep_entries if e.path not in deleted_paths

--- a/cleanacelerai/src/ui/views/asesor_view.py
+++ b/cleanacelerai/src/ui/views/asesor_view.py
@@ -1,8 +1,9 @@
 """View: Chaos Advisor — passive widget layer with tabbed interface."""
 from __future__ import annotations
 
+import os
 from tkinter import filedialog, messagebox, ttk
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Callable
 
 import customtkinter as ctk
 
@@ -18,6 +19,7 @@ from ...domain.constants import (
     COLOR_WARNING,
     DEEP_CLEAN_BUNDLE_ICONS,
     DEEP_CLEAN_RISK_COLORS,
+    PROJECT_SIGNAL_LABELS,
 )
 from ...domain.models import (
     DeepCleanBundle,
@@ -26,6 +28,7 @@ from ...domain.models import (
     DeepCleanRisk,
     DocumentAnalysisResult,
     DocumentCategory,
+    ProjectSignature,
 )
 from ...services.chaos_advisor import AdvisorEntry
 
@@ -428,6 +431,142 @@ class AsesorView(ctk.CTkFrame):
 
     def show_error(self, title: str, message: str) -> None:
         messagebox.showerror(title, message)
+
+    def show_project_confirm_dialog(
+        self,
+        signature: ProjectSignature,
+        on_confirm: Callable[[bool], None],
+    ) -> None:
+        """Modal dialog: type the folder name to confirm deletion of a project folder.
+
+        Calls on_confirm(True) when the user types the exact name and clicks Confirm.
+        Calls on_confirm(False) on Cancel or window close.
+        The 'resolved' guard ensures on_confirm fires exactly once.
+        """
+        folder_name = os.path.basename(os.path.normpath(signature.path))
+
+        w = ctk.CTkToplevel(self)
+        w.title("Confirmar eliminacion de proyecto")
+        w.geometry("560x440")
+        w.attributes("-topmost", True)
+        w.transient(self.winfo_toplevel())
+        w.grab_set()
+
+        # Guard: prevents double-callback if user presses Confirm then closes the X
+        resolved: dict[str, bool] = {"value": False}
+
+        def _resolve(confirmed: bool) -> None:
+            if resolved["value"]:
+                return
+            resolved["value"] = True
+            try:
+                w.grab_release()
+            except Exception:
+                pass
+            w.destroy()
+            on_confirm(confirmed)
+
+        # Header — folder name in danger color
+        ctk.CTkLabel(
+            w,
+            text=folder_name,
+            font=ctk.CTkFont(size=16, weight="bold"),
+            text_color=COLOR_DANGER,
+        ).pack(padx=20, pady=(20, 5), anchor="w")
+
+        # Full path (muted)
+        ctk.CTkLabel(
+            w,
+            text=signature.path,
+            font=ctk.CTkFont(size=10),
+            text_color=COLOR_TEXT_MUTED,
+            wraplength=520,
+            justify="left",
+        ).pack(padx=20, pady=(0, 10), anchor="w")
+
+        # Signals list
+        signals_text = "Senales detectadas:\n" + "\n".join(
+            f"  - {PROJECT_SIGNAL_LABELS.get(s, s)}"
+            for s in signature.signals
+        )
+        if signature.last_modified_days is not None:
+            signals_text += f"\n  - Ultima modificacion: hace {signature.last_modified_days} dia(s)"
+
+        ctk.CTkLabel(
+            w,
+            text=signals_text,
+            font=ctk.CTkFont(size=11),
+            text_color=COLOR_TEXT_MAIN,
+            justify="left",
+            anchor="w",
+        ).pack(padx=20, pady=(0, 15), anchor="w", fill="x")
+
+        # Type-to-confirm instruction
+        ctk.CTkLabel(
+            w,
+            text="Escribi el nombre exacto del proyecto para confirmar:",
+            font=ctk.CTkFont(size=11),
+            text_color=COLOR_TEXT_MAIN,
+        ).pack(padx=20, pady=(0, 5), anchor="w")
+
+        entry = ctk.CTkEntry(w, font=ctk.CTkFont(size=12))
+        entry.pack(padx=20, fill="x")
+        entry.focus_set()
+
+        # Button row
+        btn_row = ctk.CTkFrame(w, fg_color="transparent")
+        btn_row.pack(padx=20, pady=20, fill="x")
+
+        btn_cancel = ctk.CTkButton(
+            btn_row,
+            text="Cancelar",
+            fg_color=COLOR_BORDER,
+            hover_color=COLOR_TEXT_MUTED,
+            command=lambda: _resolve(False),
+        )
+        btn_cancel.pack(side="right", padx=(10, 0))
+
+        btn_confirm = ctk.CTkButton(
+            btn_row,
+            text="Eliminar",
+            fg_color=COLOR_DANGER,
+            hover_color="#B91C1C",
+            state="disabled",
+            command=lambda: _resolve(True),
+        )
+        btn_confirm.pack(side="right")
+
+        def _on_entry_change(*_args: object) -> None:
+            if entry.get() == folder_name:  # case-sensitive exact match
+                btn_confirm.configure(state="normal")
+            else:
+                btn_confirm.configure(state="disabled")
+
+        entry.bind("<KeyRelease>", _on_entry_change)
+
+        # Window close button (X) -> cancel
+        w.protocol("WM_DELETE_WINDOW", lambda: _resolve(False))
+
+    def show_project_move_warning_dialog(
+        self,
+        signature: ProjectSignature,
+        on_confirm: Callable[[bool], None],
+    ) -> None:
+        """Warning dialog for moving a folder that looks like a live project.
+
+        Uses messagebox.askyesno for simplicity (matches other Asesor confirmations).
+        Default answer is 'No' so an accidental Enter cancels.
+        """
+        folder_name = os.path.basename(os.path.normpath(signature.path))
+        answer = messagebox.askyesno(
+            "Mover proyecto",
+            f"'{folder_name}' parece ser un proyecto activo.\n\n"
+            "Si lo moves, los paths relativos (imports, configs, .git) pueden romperse.\n\n"
+            "Continuar con el movimiento?",
+            icon="warning",
+            default="no",
+        )
+        on_confirm(answer)
 
     # ── Public API for presenter — Tab 2 (Documentos) ──────────────────────
 

--- a/cleanacelerai/tests/test_asesor_presenter.py
+++ b/cleanacelerai/tests/test_asesor_presenter.py
@@ -441,6 +441,38 @@ class TestDeleteItems:
         assert mock_sdd.call_count == 2
         assert len(view.remove_item_calls) == 2
 
+    def test_delete_items_fallback_and_error_both_surfaced(self) -> None:
+        """Regression for W-2: when a batch has BOTH fallback renames AND hard errors,
+        both summaries must reach the user. Old elif-only branch suppressed the error
+        summary when any fallback existed."""
+        presenter, view = self._make_presenter()
+
+        items = [
+            ("id1", r"C:\plain\folder1", "folder1"),
+            ("id2", r"C:\plain\folder2", "folder2"),
+        ]
+
+        with (
+            patch(
+                "src.ui.presenters.asesor_presenter.safe_delete_dir",
+                side_effect=[
+                    (True, r"FALLBACK_RENAME:C:\plain\folder1.UNSAFE-CANT-RECYCLE.20250101T000000.bak"),
+                    (False, "OSError: permission denied"),
+                ],
+            ),
+            patch("src.ui.presenters.asesor_presenter.detect_project_signature", return_value=None),
+            patch("os.path.isdir", return_value=True),
+        ):
+            presenter.delete_items(items)
+
+        warning_titles = [title.lower() for title, _msg in view.show_warning_calls]
+        assert any("fallback" in t for t in warning_titles), (
+            f"Missing fallback warning. Got titles: {warning_titles}"
+        )
+        assert any("error" in t for t in warning_titles), (
+            f"Missing error warning. Got titles: {warning_titles}"
+        )
+
 
 # ---------------------------------------------------------------------------
 # TASK 6 — move_items tests

--- a/cleanacelerai/tests/test_asesor_presenter.py
+++ b/cleanacelerai/tests/test_asesor_presenter.py
@@ -1,0 +1,531 @@
+"""Tests for ui/presenters/asesor_presenter.py — safe delete refactor."""
+from __future__ import annotations
+
+from typing import Any, Callable
+from unittest.mock import MagicMock, call, patch
+
+import pytest
+
+from src.domain.models import DeepCleanEntry, DeepCleanRisk, DeepCleanBundle, ProjectSignature
+
+
+# ---------------------------------------------------------------------------
+# FakeView — captures all view method calls; supports simulated dialog callbacks
+# ---------------------------------------------------------------------------
+
+class FakeView:
+    """Fake view that records all show_* calls and supports dialog callbacks.
+
+    Use a fresh FakeView instance per test (no class-level state).
+    """
+
+    def __init__(self) -> None:
+        self.show_info_calls: list[tuple[str, str]] = []
+        self.show_warning_calls: list[tuple[str, str]] = []
+        self.show_error_calls: list[tuple[str, str]] = []
+        self.remove_item_calls: list[str] = []
+        self.remove_deep_entry_calls: list[str] = []
+        self.show_project_confirm_dialog_calls: list[tuple[ProjectSignature, Callable]] = []
+        self.show_project_move_warning_dialog_calls: list[tuple[ProjectSignature, Callable]] = []
+
+    # --- View API ---
+
+    def show_info(self, title: str, message: str) -> None:
+        self.show_info_calls.append((title, message))
+
+    def show_warning(self, title: str, message: str) -> None:
+        self.show_warning_calls.append((title, message))
+
+    def show_error(self, title: str, message: str) -> None:
+        self.show_error_calls.append((title, message))
+
+    def remove_item(self, item_id: str) -> None:
+        self.remove_item_calls.append(item_id)
+
+    def remove_deep_entry(self, path: str) -> None:
+        self.remove_deep_entry_calls.append(path)
+
+    def show_project_confirm_dialog(
+        self,
+        signature: ProjectSignature,
+        on_confirm: Callable[[bool], None],
+    ) -> None:
+        self.show_project_confirm_dialog_calls.append((signature, on_confirm))
+
+    def show_project_move_warning_dialog(
+        self,
+        signature: ProjectSignature,
+        on_confirm: Callable[[bool], None],
+    ) -> None:
+        self.show_project_move_warning_dialog_calls.append((signature, on_confirm))
+
+    # --- No-op stubs for presenter methods that call other view methods ---
+
+    def set_deep_scan_enabled(self, enabled: bool) -> None:
+        pass
+
+    def set_deep_bulk_enabled(self, enabled: bool) -> None:
+        pass
+
+    def show_deep_progress(self, visible: bool) -> None:
+        pass
+
+    def update_entry_size(self, path: str, size: int) -> None:
+        pass
+
+    def show_deep_summary(self, count: int, total: int) -> None:
+        pass
+
+    def display_deep_entries(self, entries: list) -> None:
+        pass
+
+    def update_deep_progress(self, value: float) -> None:
+        pass
+
+    def after(self, delay: int, callback: Callable, *args: Any) -> None:
+        """Immediate execution — no Tk event loop in tests."""
+        callback(*args)
+
+
+# ---------------------------------------------------------------------------
+# Helper to build a DeepCleanEntry quickly
+# ---------------------------------------------------------------------------
+
+def _make_entry(
+    path: str = r"C:\cache\entry",
+    name: str = "entry",
+    risk: DeepCleanRisk = DeepCleanRisk.CACHE,
+    size_bytes: int = 1024,
+    delete_instructions: str | None = None,
+) -> DeepCleanEntry:
+    return DeepCleanEntry(
+        path=path,
+        name=name,
+        size_bytes=size_bytes,
+        risk=risk,
+        bundle=DeepCleanBundle.CACHE_TEMP,
+        description="Cache folder",
+        creator="Test",
+        last_modified=None,
+        is_in_use=False,
+        special_note=None,
+        delete_instructions=delete_instructions,
+    )
+
+
+# ---------------------------------------------------------------------------
+# TASK 4 — delete_deep_entry tests
+# ---------------------------------------------------------------------------
+
+class TestDeleteDeepEntry:
+    """Tests for delete_deep_entry using safe_delete_dir (no shutil.rmtree)."""
+
+    def _make_presenter(self) -> tuple:
+        """Return (presenter, fake_view) with one CACHE entry pre-loaded."""
+        from src.ui.presenters.asesor_presenter import AsesorPresenter
+
+        view = FakeView()
+        presenter = AsesorPresenter(view)
+        entry = _make_entry(path=r"C:\cache\node_modules", name="node_modules")
+        presenter._deep_entries = [entry]
+        return presenter, view
+
+    def test_delete_deep_entry_uses_safe_delete_dir(self) -> None:
+        """spec scenario 19: safe_delete_dir called, shutil.rmtree NOT called."""
+        presenter, view = self._make_presenter()
+
+        with (
+            patch("src.ui.presenters.asesor_presenter.safe_delete_dir", return_value=(True, "")) as mock_sdd,
+            patch("tkinter.messagebox.askyesno", return_value=True),
+        ):
+            presenter.delete_deep_entry(r"C:\cache\node_modules")
+
+        mock_sdd.assert_called_once()
+        assert view.show_info_calls, "show_info should be called on success"
+
+    def test_delete_deep_entry_fallback_shows_warning(self) -> None:
+        """spec scenario 20: FALLBACK_RENAME result triggers view.show_warning."""
+        presenter, view = self._make_presenter()
+
+        with (
+            patch(
+                "src.ui.presenters.asesor_presenter.safe_delete_dir",
+                return_value=(True, r"FALLBACK_RENAME:C:\cache\node_modules.UNSAFE-CANT-RECYCLE.20250101T000000.bak"),
+            ),
+            patch("tkinter.messagebox.askyesno", return_value=True),
+        ):
+            presenter.delete_deep_entry(r"C:\cache\node_modules")
+
+        assert view.show_warning_calls, "show_warning should be called for fallback rename"
+
+    def test_delete_deep_entry_hard_failure_shows_error(self) -> None:
+        """spec scenario 21: hard failure (False, error) triggers view.show_error."""
+        presenter, view = self._make_presenter()
+
+        with (
+            patch(
+                "src.ui.presenters.asesor_presenter.safe_delete_dir",
+                return_value=(False, "disk error"),
+            ),
+            patch("tkinter.messagebox.askyesno", return_value=True),
+        ):
+            presenter.delete_deep_entry(r"C:\cache\node_modules")
+
+        assert view.show_error_calls, "show_error should be called on hard failure"
+
+    def test_delete_deep_entry_source_is_limpieza_profunda(self) -> None:
+        """safe_delete_dir must be called with source='asesor.limpieza-profunda'."""
+        presenter, view = self._make_presenter()
+
+        with (
+            patch("src.ui.presenters.asesor_presenter.safe_delete_dir", return_value=(True, "")) as mock_sdd,
+            patch("tkinter.messagebox.askyesno", return_value=True),
+        ):
+            presenter.delete_deep_entry(r"C:\cache\node_modules")
+
+        call_args = mock_sdd.call_args
+        assert call_args is not None
+        # Check source kwarg
+        kwargs = call_args[1] if call_args[1] else {}
+        args = call_args[0] if call_args[0] else ()
+        source = kwargs.get("source") or (args[1] if len(args) > 1 else None)
+        assert source == "asesor.limpieza-profunda"
+
+    def test_delete_deep_entry_entry_removed_from_list(self) -> None:
+        """After success, the entry is removed from _deep_entries."""
+        presenter, view = self._make_presenter()
+
+        with (
+            patch("src.ui.presenters.asesor_presenter.safe_delete_dir", return_value=(True, "")),
+            patch("tkinter.messagebox.askyesno", return_value=True),
+        ):
+            presenter.delete_deep_entry(r"C:\cache\node_modules")
+
+        assert not any(e.path == r"C:\cache\node_modules" for e in presenter._deep_entries)
+
+
+# ---------------------------------------------------------------------------
+# TASK 4 — bulk_delete_safe tests
+# ---------------------------------------------------------------------------
+
+class TestBulkDeleteSafe:
+    """Tests for bulk_delete_safe using safe_delete_dir (no shutil.rmtree)."""
+
+    def _make_presenter_with_entries(self, n: int = 2) -> tuple:
+        from src.ui.presenters.asesor_presenter import AsesorPresenter
+
+        view = FakeView()
+        presenter = AsesorPresenter(view)
+        entries = [
+            _make_entry(path=rf"C:\cache\entry{i}", name=f"entry{i}", size_bytes=1024)
+            for i in range(n)
+        ]
+        presenter._deep_entries = entries
+        return presenter, view
+
+    def test_bulk_delete_safe_uses_safe_delete_dir(self) -> None:
+        """spec scenario 22: each entry deleted via safe_delete_dir, not shutil.rmtree."""
+        presenter, view = self._make_presenter_with_entries(2)
+
+        with (
+            patch("src.ui.presenters.asesor_presenter.safe_delete_dir", return_value=(True, "")) as mock_sdd,
+            patch("tkinter.messagebox.askyesno", return_value=True),
+        ):
+            presenter.bulk_delete_safe()
+
+        assert mock_sdd.call_count == 2
+
+    def test_bulk_delete_safe_fallback_in_errors(self) -> None:
+        """spec scenario 23: one entry returns fallback → appears in errors / warning."""
+        presenter, view = self._make_presenter_with_entries(2)
+
+        side_effects = [
+            (True, ""),
+            (True, r"FALLBACK_RENAME:C:\cache\entry1.UNSAFE-CANT-RECYCLE.20250101T000000.bak"),
+        ]
+
+        with (
+            patch("src.ui.presenters.asesor_presenter.safe_delete_dir", side_effect=side_effects),
+            patch("tkinter.messagebox.askyesno", return_value=True),
+        ):
+            presenter.bulk_delete_safe()
+
+        # The fallback should be surfaced via show_warning
+        assert view.show_warning_calls, "show_warning should be called when fallback occurred"
+
+    def test_bulk_delete_safe_source_is_bulk_safe(self) -> None:
+        """safe_delete_dir must be called with source='asesor.bulk-safe'."""
+        presenter, view = self._make_presenter_with_entries(1)
+
+        with (
+            patch("src.ui.presenters.asesor_presenter.safe_delete_dir", return_value=(True, "")) as mock_sdd,
+            patch("tkinter.messagebox.askyesno", return_value=True),
+        ):
+            presenter.bulk_delete_safe()
+
+        call_args = mock_sdd.call_args
+        assert call_args is not None
+        kwargs = call_args[1] if call_args[1] else {}
+        args = call_args[0] if call_args[0] else ()
+        source = kwargs.get("source") or (args[1] if len(args) > 1 else None)
+        assert source == "asesor.bulk-safe"
+
+    def test_bulk_delete_safe_deleted_count_correct(self) -> None:
+        """Deleted count in summary should match number of successful deletions."""
+        presenter, view = self._make_presenter_with_entries(3)
+
+        with (
+            patch("src.ui.presenters.asesor_presenter.safe_delete_dir", return_value=(True, "")),
+            patch("tkinter.messagebox.askyesno", return_value=True),
+        ):
+            presenter.bulk_delete_safe()
+
+        # All 3 should be in remove_deep_entry calls
+        assert len(view.remove_deep_entry_calls) == 3
+
+
+# ---------------------------------------------------------------------------
+# TASK 5 — delete_items tests
+# ---------------------------------------------------------------------------
+
+class TestDeleteItems:
+    """Tests for the refactored delete_items (queue-based, no shutil.rmtree)."""
+
+    def _make_presenter(self) -> tuple:
+        from src.ui.presenters.asesor_presenter import AsesorPresenter
+
+        view = FakeView()
+        presenter = AsesorPresenter(view)
+        return presenter, view
+
+    def test_delete_items_file_uses_safe_delete(self) -> None:
+        """spec scenario 12: file item -> safe_delete called, NOT safe_delete_dir."""
+        presenter, view = self._make_presenter()
+
+        with (
+            patch("src.ui.presenters.asesor_presenter.safe_delete", return_value=(True, "")) as mock_sd,
+            patch("src.ui.presenters.asesor_presenter.safe_delete_dir") as mock_sdd,
+            patch("os.path.isdir", return_value=False),
+        ):
+            presenter.delete_items([("id1", r"C:\folder\file.txt", "file.txt")])
+
+        mock_sd.assert_called_once()
+        mock_sdd.assert_not_called()
+
+    def test_delete_items_plain_dir_uses_safe_delete_dir(self) -> None:
+        """spec scenario 13: dir + detector returns None -> safe_delete_dir called, no dialog."""
+        presenter, view = self._make_presenter()
+
+        with (
+            patch("src.ui.presenters.asesor_presenter.safe_delete_dir", return_value=(True, "")) as mock_sdd,
+            patch("src.ui.presenters.asesor_presenter.detect_project_signature", return_value=None),
+            patch("os.path.isdir", return_value=True),
+        ):
+            presenter.delete_items([("id1", r"C:\plain\folder", "folder")])
+
+        mock_sdd.assert_called_once()
+        assert not view.show_project_confirm_dialog_calls
+
+    def test_delete_items_project_dir_shows_dialog(self) -> None:
+        """spec scenario 14: dir + ProjectSignature -> show_project_confirm_dialog called."""
+        presenter, view = self._make_presenter()
+
+        sig = ProjectSignature(
+            path=r"C:\Mis_proyectos\myapp",
+            signals=("inside-mis-proyectos",),
+            last_modified_days=1,
+        )
+
+        with (
+            patch("src.ui.presenters.asesor_presenter.detect_project_signature", return_value=sig),
+            patch("os.path.isdir", return_value=True),
+        ):
+            presenter.delete_items([("id1", r"C:\Mis_proyectos\myapp", "myapp")])
+
+        assert len(view.show_project_confirm_dialog_calls) == 1
+
+    def test_delete_items_dialog_confirmed_calls_safe_delete_dir(self) -> None:
+        """spec scenario 15: on_confirm(True) -> safe_delete_dir called."""
+        presenter, view = self._make_presenter()
+
+        sig = ProjectSignature(
+            path=r"C:\Mis_proyectos\myapp",
+            signals=("inside-mis-proyectos",),
+            last_modified_days=1,
+        )
+
+        with (
+            patch("src.ui.presenters.asesor_presenter.safe_delete_dir", return_value=(True, "")) as mock_sdd,
+            patch("src.ui.presenters.asesor_presenter.detect_project_signature", return_value=sig),
+            patch("os.path.isdir", return_value=True),
+        ):
+            presenter.delete_items([("id1", r"C:\Mis_proyectos\myapp", "myapp")])
+            # Simulate user confirming
+            assert view.show_project_confirm_dialog_calls
+            _, on_confirm = view.show_project_confirm_dialog_calls[0]
+            on_confirm(True)
+
+        mock_sdd.assert_called_once()
+
+    def test_delete_items_dialog_cancelled_skips_delete(self) -> None:
+        """spec scenario 16: on_confirm(False) -> safe_delete_dir NOT called."""
+        presenter, view = self._make_presenter()
+
+        sig = ProjectSignature(
+            path=r"C:\Mis_proyectos\myapp",
+            signals=("inside-mis-proyectos",),
+            last_modified_days=1,
+        )
+
+        with (
+            patch("src.ui.presenters.asesor_presenter.safe_delete_dir") as mock_sdd,
+            patch("src.ui.presenters.asesor_presenter.detect_project_signature", return_value=sig),
+            patch("os.path.isdir", return_value=True),
+        ):
+            presenter.delete_items([("id1", r"C:\Mis_proyectos\myapp", "myapp")])
+            assert view.show_project_confirm_dialog_calls
+            _, on_confirm = view.show_project_confirm_dialog_calls[0]
+            on_confirm(False)
+
+        mock_sdd.assert_not_called()
+
+    def test_delete_items_source_is_orden_general(self) -> None:
+        """safe_delete_dir must be called with source='asesor.orden-general'."""
+        presenter, view = self._make_presenter()
+
+        with (
+            patch("src.ui.presenters.asesor_presenter.safe_delete_dir", return_value=(True, "")) as mock_sdd,
+            patch("src.ui.presenters.asesor_presenter.detect_project_signature", return_value=None),
+            patch("os.path.isdir", return_value=True),
+        ):
+            presenter.delete_items([("id1", r"C:\plain\folder", "folder")])
+
+        call_args = mock_sdd.call_args
+        kwargs = call_args[1] if call_args[1] else {}
+        args = call_args[0] if call_args[0] else ()
+        source = kwargs.get("source") or (args[1] if len(args) > 1 else None)
+        assert source == "asesor.orden-general"
+
+    def test_delete_items_fallback_surfaces_warning(self) -> None:
+        """spec scenario 31: FALLBACK_RENAME -> view.show_warning called."""
+        presenter, view = self._make_presenter()
+
+        with (
+            patch(
+                "src.ui.presenters.asesor_presenter.safe_delete_dir",
+                return_value=(True, r"FALLBACK_RENAME:C:\plain\folder.UNSAFE-CANT-RECYCLE.20250101T000000.bak"),
+            ),
+            patch("src.ui.presenters.asesor_presenter.detect_project_signature", return_value=None),
+            patch("os.path.isdir", return_value=True),
+        ):
+            presenter.delete_items([("id1", r"C:\plain\folder", "folder")])
+
+        assert view.show_warning_calls
+
+    def test_delete_items_multiple_items_queue_processes_all(self) -> None:
+        """Queue processes all plain items correctly."""
+        presenter, view = self._make_presenter()
+
+        items = [
+            ("id1", r"C:\plain\folder1", "folder1"),
+            ("id2", r"C:\plain\folder2", "folder2"),
+        ]
+
+        with (
+            patch("src.ui.presenters.asesor_presenter.safe_delete_dir", return_value=(True, "")) as mock_sdd,
+            patch("src.ui.presenters.asesor_presenter.detect_project_signature", return_value=None),
+            patch("os.path.isdir", return_value=True),
+        ):
+            presenter.delete_items(items)
+
+        assert mock_sdd.call_count == 2
+        assert len(view.remove_item_calls) == 2
+
+
+# ---------------------------------------------------------------------------
+# TASK 6 — move_items tests
+# ---------------------------------------------------------------------------
+
+class TestMoveItems:
+    """Tests for the refactored move_items (queue-based, project warning)."""
+
+    def _make_presenter(self) -> tuple:
+        from src.ui.presenters.asesor_presenter import AsesorPresenter
+
+        view = FakeView()
+        presenter = AsesorPresenter(view)
+        return presenter, view
+
+    def test_move_items_non_project_no_dialog(self) -> None:
+        """spec scenario 17: dir + detector returns None -> no dialog, shutil.move called."""
+        presenter, view = self._make_presenter()
+
+        with (
+            patch("src.ui.presenters.asesor_presenter.detect_project_signature", return_value=None),
+            patch("os.path.isdir", return_value=True),
+            patch("shutil.move") as mock_move,
+        ):
+            presenter.move_items([("id1", r"C:\plain\folder", "folder")], r"C:\dest")
+
+        mock_move.assert_called_once()
+        assert not view.show_project_move_warning_dialog_calls
+
+    def test_move_items_project_shows_warning_dialog(self) -> None:
+        """spec scenario 18: dir + ProjectSignature -> show_project_move_warning_dialog called."""
+        presenter, view = self._make_presenter()
+
+        sig = ProjectSignature(
+            path=r"C:\Mis_proyectos\myapp",
+            signals=("inside-mis-proyectos",),
+            last_modified_days=1,
+        )
+
+        with (
+            patch("src.ui.presenters.asesor_presenter.detect_project_signature", return_value=sig),
+            patch("os.path.isdir", return_value=True),
+        ):
+            presenter.move_items([("id1", r"C:\Mis_proyectos\myapp", "myapp")], r"C:\dest")
+
+        assert len(view.show_project_move_warning_dialog_calls) == 1
+
+    def test_move_items_project_confirmed_proceeds(self) -> None:
+        """Simulate on_continue(True) -> shutil.move called."""
+        presenter, view = self._make_presenter()
+
+        sig = ProjectSignature(
+            path=r"C:\Mis_proyectos\myapp",
+            signals=("inside-mis-proyectos",),
+            last_modified_days=1,
+        )
+
+        with (
+            patch("src.ui.presenters.asesor_presenter.detect_project_signature", return_value=sig),
+            patch("os.path.isdir", return_value=True),
+            patch("shutil.move") as mock_move,
+        ):
+            presenter.move_items([("id1", r"C:\Mis_proyectos\myapp", "myapp")], r"C:\dest")
+            _, on_confirm = view.show_project_move_warning_dialog_calls[0]
+            on_confirm(True)
+
+        mock_move.assert_called_once()
+
+    def test_move_items_project_cancelled_aborts(self) -> None:
+        """Simulate on_continue(False) -> shutil.move NOT called."""
+        presenter, view = self._make_presenter()
+
+        sig = ProjectSignature(
+            path=r"C:\Mis_proyectos\myapp",
+            signals=("inside-mis-proyectos",),
+            last_modified_days=1,
+        )
+
+        with (
+            patch("src.ui.presenters.asesor_presenter.detect_project_signature", return_value=sig),
+            patch("os.path.isdir", return_value=True),
+            patch("shutil.move") as mock_move,
+        ):
+            presenter.move_items([("id1", r"C:\Mis_proyectos\myapp", "myapp")], r"C:\dest")
+            _, on_confirm = view.show_project_move_warning_dialog_calls[0]
+            on_confirm(False)
+
+        mock_move.assert_not_called()

--- a/cleanacelerai/tests/test_file_system.py
+++ b/cleanacelerai/tests/test_file_system.py
@@ -7,7 +7,7 @@ from unittest.mock import MagicMock, call, patch
 
 import pytest
 
-from src.infrastructure.file_system import _log_deletion, safe_delete
+from src.infrastructure.file_system import _log_deletion, safe_delete, safe_delete_dir
 
 
 class TestLogDeletion:
@@ -165,3 +165,162 @@ class TestSafeDelete:
 
         assert ok is True
         assert err == ""
+
+
+class TestLogDeletionExtended:
+    """Tests for the extended _log_deletion signature (source + fallback_rename)."""
+
+    def test_log_deletion_with_source(self, tmp_path: Path) -> None:
+        """GIVEN source is provided, THEN log line contains 'source' key."""
+        target = tmp_path / "deleteme.txt"
+        target.write_bytes(b"data " * 200)
+
+        with patch.object(Path, "home", staticmethod(lambda: tmp_path)):
+            _log_deletion(str(target), source="asesor.orden-general")
+
+        log_path = tmp_path / ".cleanacelerai" / "deleted.log"
+        entry = json.loads(log_path.read_text(encoding="utf-8").strip())
+        assert "source" in entry
+        assert entry["source"] == "asesor.orden-general"
+
+    def test_log_deletion_without_source(self, tmp_path: Path) -> None:
+        """GIVEN no source (existing callers), THEN log line has NO 'source' key."""
+        target = tmp_path / "deleteme.txt"
+        target.write_bytes(b"data " * 200)
+
+        with patch.object(Path, "home", staticmethod(lambda: tmp_path)):
+            _log_deletion(str(target))  # no source kwarg
+
+        log_path = tmp_path / ".cleanacelerai" / "deleted.log"
+        entry = json.loads(log_path.read_text(encoding="utf-8").strip())
+        assert "source" not in entry  # backward-compatible shape
+
+    def test_log_deletion_with_fallback_rename(self, tmp_path: Path) -> None:
+        """GIVEN fallback_rename=True, THEN log line includes fallback_rename: true."""
+        target = tmp_path / "deleteme.txt"
+        target.write_bytes(b"data " * 200)
+
+        with patch.object(Path, "home", staticmethod(lambda: tmp_path)):
+            _log_deletion(str(target), source="asesor", fallback_rename=True)
+
+        log_path = tmp_path / ".cleanacelerai" / "deleted.log"
+        entry = json.loads(log_path.read_text(encoding="utf-8").strip())
+        assert entry.get("fallback_rename") is True
+
+
+class TestSafeDeleteDir:
+    """Tests for safe_delete_dir — directory-safe deletion via send2trash."""
+
+    def test_safe_delete_dir_success(self, tmp_path: Path) -> None:
+        """GIVEN valid dir and send2trash succeeds, THEN returns (True, '') and logs."""
+        target = tmp_path / "mydir"
+        target.mkdir()
+
+        with (
+            patch("src.infrastructure.file_system.send2trash") as mock_trash,
+            patch("src.infrastructure.file_system._log_deletion") as mock_log,
+        ):
+            ok, err = safe_delete_dir(str(target))
+
+        assert ok is True
+        assert err == ""
+        mock_trash.assert_called_once()
+        mock_log.assert_called()
+
+    def test_safe_delete_dir_logs_before_trashing(self, tmp_path: Path) -> None:
+        """Log call MUST happen BEFORE send2trash call."""
+        target = tmp_path / "mydir"
+        target.mkdir()
+
+        call_order: list[str] = []
+
+        def fake_log(path: str, source: str | None = None, fallback_rename: bool = False) -> None:
+            call_order.append("log")
+
+        def fake_trash(path: str) -> None:
+            call_order.append("trash")
+
+        with (
+            patch("src.infrastructure.file_system._log_deletion", side_effect=fake_log),
+            patch("src.infrastructure.file_system.send2trash", side_effect=fake_trash),
+        ):
+            safe_delete_dir(str(target))
+
+        assert call_order[0] == "log", "Log must happen BEFORE trash"
+        assert "trash" in call_order
+
+    def test_safe_delete_dir_fallback_rename(self, tmp_path: Path) -> None:
+        """GIVEN TrashPermissionError, THEN fallback rename happens and returns FALLBACK_RENAME prefix."""
+        from send2trash import TrashPermissionError
+
+        target = tmp_path / "mydir"
+        target.mkdir()
+
+        with (
+            patch("src.infrastructure.file_system.send2trash", side_effect=TrashPermissionError("no recycle")),
+            patch("src.infrastructure.file_system._log_deletion") as mock_log,
+            patch("os.rename") as mock_rename,
+        ):
+            ok, err = safe_delete_dir(str(target), source="asesor.orden-general")
+
+        assert ok is True
+        assert err.startswith("FALLBACK_RENAME:")
+        # _log_deletion should be called twice: once before send2trash, once for fallback
+        assert mock_log.call_count == 2
+        # Second call should have fallback_rename=True
+        _, kwargs = mock_log.call_args_list[1]
+        assert kwargs.get("fallback_rename") is True or mock_log.call_args_list[1][1].get("fallback_rename") is True
+
+    def test_safe_delete_dir_hard_failure(self, tmp_path: Path) -> None:
+        """GIVEN OSError (not TrashPermissionError), THEN returns (False, error_msg)."""
+        target = tmp_path / "mydir"
+        target.mkdir()
+
+        with (
+            patch("src.infrastructure.file_system.send2trash", side_effect=OSError("disk error")),
+            patch("src.infrastructure.file_system._log_deletion"),
+        ):
+            ok, err = safe_delete_dir(str(target))
+
+        assert ok is False
+        assert "disk error" in err
+
+    def test_safe_delete_dir_not_a_directory(self, tmp_path: Path) -> None:
+        """GIVEN a file path (not a dir), THEN returns (False, ...) immediately."""
+        target = tmp_path / "file.txt"
+        target.write_bytes(b"hi")
+
+        ok, err = safe_delete_dir(str(target))
+        assert ok is False
+
+    def test_safe_delete_dir_already_gone(self, tmp_path: Path) -> None:
+        """GIVEN FileNotFoundError from send2trash, THEN returns (True, '') — already gone."""
+        target = tmp_path / "mydir"
+        target.mkdir()
+
+        with (
+            patch("src.infrastructure.file_system.send2trash", side_effect=FileNotFoundError()),
+            patch("src.infrastructure.file_system._log_deletion"),
+        ):
+            ok, err = safe_delete_dir(str(target))
+
+        assert ok is True
+        assert err == ""
+
+    def test_safe_delete_dir_source_passed_to_log(self, tmp_path: Path) -> None:
+        """GIVEN source kwarg, THEN _log_deletion is called with that source."""
+        target = tmp_path / "mydir"
+        target.mkdir()
+
+        with (
+            patch("src.infrastructure.file_system.send2trash"),
+            patch("src.infrastructure.file_system._log_deletion") as mock_log,
+        ):
+            safe_delete_dir(str(target), source="asesor.limpieza-profunda")
+
+        first_call_kwargs = mock_log.call_args_list[0]
+        # Check that source="asesor.limpieza-profunda" was passed
+        args, kwargs = first_call_kwargs
+        assert kwargs.get("source") == "asesor.limpieza-profunda" or (
+            len(args) > 1 and args[1] == "asesor.limpieza-profunda"
+        )

--- a/cleanacelerai/tests/test_models.py
+++ b/cleanacelerai/tests/test_models.py
@@ -4,6 +4,49 @@ import pytest
 from src.domain.models import CleanupResult, DuplicateGroup, FileInfo, RiskLevel
 
 
+class TestProjectSignature:
+    """Tests for the ProjectSignature value object (Domain A)."""
+
+    def test_project_signature_instantiation(self) -> None:
+        """GIVEN valid path/signals/last_modified_days, THEN fields are accessible."""
+        from src.domain.models import ProjectSignature
+
+        sig = ProjectSignature(
+            path=r"C:\Mis_proyectos\myapp",
+            signals=("has-git", "has-package-json"),
+            last_modified_days=3,
+        )
+        assert sig.path == r"C:\Mis_proyectos\myapp"
+        assert "has-git" in sig.signals
+        assert "has-package-json" in sig.signals
+        assert sig.last_modified_days == 3
+
+    def test_project_signature_is_frozen(self) -> None:
+        """THEN assigning to a field raises FrozenInstanceError."""
+        from dataclasses import FrozenInstanceError
+
+        from src.domain.models import ProjectSignature
+
+        sig = ProjectSignature(
+            path=r"C:\Mis_proyectos\myapp",
+            signals=("has-git",),
+            last_modified_days=None,
+        )
+        with pytest.raises(FrozenInstanceError):
+            sig.path = r"C:\other"  # type: ignore[misc]
+
+    def test_project_signature_signals_is_tuple(self) -> None:
+        """THEN signals is a tuple, not a list."""
+        from src.domain.models import ProjectSignature
+
+        sig = ProjectSignature(
+            path=r"C:\Mis_proyectos\myapp",
+            signals=("has-git",),
+            last_modified_days=0,
+        )
+        assert isinstance(sig.signals, tuple)
+
+
 class TestFileInfo:
     def test_size_mb(self) -> None:
         fi = FileInfo(path=r"C:\foo\bar.txt", size=2 * 1024 * 1024, mtime=0.0)

--- a/cleanacelerai/tests/test_project_detector.py
+++ b/cleanacelerai/tests/test_project_detector.py
@@ -1,0 +1,200 @@
+"""Tests for services/project_detector.py — detect_project_signature."""
+from __future__ import annotations
+
+import os
+import time
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from src.services.project_detector import detect_project_signature
+
+
+class TestPathSignals:
+    """Path-based signal detection (no filesystem listing needed)."""
+
+    def test_path_signal_mis_proyectos(self, tmp_path: Path) -> None:
+        """GIVEN a path containing \\Mis_proyectos\\, THEN signal is present."""
+        folder = tmp_path / "Mis_proyectos" / "myapp"
+        folder.mkdir(parents=True)
+        path_str = str(folder)
+
+        result = detect_project_signature(path_str)
+        assert result is not None
+        assert "inside-mis-proyectos" in result.signals
+
+    def test_path_signal_local_sites(self, tmp_path: Path) -> None:
+        """GIVEN a path containing \\Local Sites\\, THEN signal is present."""
+        folder = tmp_path / "Local Sites" / "mysite"
+        folder.mkdir(parents=True)
+        path_str = str(folder)
+
+        result = detect_project_signature(path_str)
+        assert result is not None
+        assert "inside-local-sites" in result.signals
+
+
+class TestFileSignals:
+    """File-based signal detection using real tmp_path directories."""
+
+    def test_file_signal_has_git(self, tmp_path: Path) -> None:
+        """GIVEN a folder containing .git dir, THEN has-git signal."""
+        git_dir = tmp_path / ".git"
+        git_dir.mkdir()
+
+        result = detect_project_signature(str(tmp_path))
+        assert result is not None
+        assert "has-git" in result.signals
+
+    def test_file_signal_has_package_json(self, tmp_path: Path) -> None:
+        """GIVEN a folder containing package.json, THEN has-package-json signal."""
+        (tmp_path / "package.json").write_text("{}", encoding="utf-8")
+
+        result = detect_project_signature(str(tmp_path))
+        assert result is not None
+        assert "has-package-json" in result.signals
+
+    def test_file_signal_has_composer_json(self, tmp_path: Path) -> None:
+        """GIVEN a folder containing composer.json, THEN has-composer-json signal."""
+        (tmp_path / "composer.json").write_text("{}", encoding="utf-8")
+
+        result = detect_project_signature(str(tmp_path))
+        assert result is not None
+        assert "has-composer-json" in result.signals
+
+    @pytest.mark.parametrize("filename,expected_signal", [
+        ("pyproject.toml", "has-pyproject-toml"),
+        ("Cargo.toml", "has-cargo-toml"),
+        ("go.mod", "has-go-mod"),
+        ("pom.xml", "has-pom-xml"),
+        ("MyProject.sln", "has-solution-file"),
+        ("MyProject.csproj", "has-csproj"),
+        ("wp-config.php", "has-wp-config"),
+        ("Gemfile", "has-gemfile"),
+    ])
+    def test_file_signal_other_markers(
+        self,
+        tmp_path: Path,
+        filename: str,
+        expected_signal: str,
+    ) -> None:
+        """GIVEN a folder containing a known marker file, THEN the correct signal."""
+        (tmp_path / filename).write_text("", encoding="utf-8")
+
+        result = detect_project_signature(str(tmp_path))
+        assert result is not None, f"Expected signal for {filename!r}"
+        assert expected_signal in result.signals, (
+            f"Expected {expected_signal!r} for {filename!r}, got {result.signals}"
+        )
+
+
+class TestSignalStacking:
+    """Multiple signals stack into one ProjectSignature."""
+
+    def test_multiple_signals_combined(self, tmp_path: Path) -> None:
+        """GIVEN Mis_proyectos path + .git dir + package.json, THEN 3 signals."""
+        # Build Mis_proyectos path
+        mis_path = tmp_path / "Mis_proyectos" / "myapp"
+        mis_path.mkdir(parents=True)
+        (mis_path / ".git").mkdir()
+        (mis_path / "package.json").write_text("{}")
+
+        result = detect_project_signature(str(mis_path))
+        assert result is not None
+        assert "inside-mis-proyectos" in result.signals
+        assert "has-git" in result.signals
+        assert "has-package-json" in result.signals
+
+
+class TestNoSignal:
+    """Plain folder with no signals returns None."""
+
+    def test_no_signals_returns_none(self, tmp_path: Path) -> None:
+        """GIVEN a folder with no recognised markers, THEN result is None."""
+        (tmp_path / "readme.txt").write_text("hello")
+
+        result = detect_project_signature(str(tmp_path))
+        assert result is None
+
+    def test_empty_folder_returns_none(self, tmp_path: Path) -> None:
+        """GIVEN an empty folder, THEN result is None."""
+        result = detect_project_signature(str(tmp_path))
+        assert result is None
+
+    def test_nonexistent_path_returns_none(self) -> None:
+        """GIVEN a path that does not exist, THEN result is None."""
+        result = detect_project_signature(r"C:\does\not\exist\ever")
+        assert result is None
+
+
+class TestErrorHandling:
+    """Safe error handling — never raises."""
+
+    def test_permission_error_returns_none(self, tmp_path: Path) -> None:
+        """GIVEN os.listdir raises PermissionError, THEN result is None."""
+        with patch("os.listdir", side_effect=PermissionError("denied")):
+            result = detect_project_signature(str(tmp_path))
+        assert result is None
+
+    def test_symlink_path_returns_none(self, tmp_path: Path) -> None:
+        """GIVEN path is a symlink, THEN result is None (not followed)."""
+        with patch("os.path.islink", return_value=True):
+            result = detect_project_signature(str(tmp_path))
+        assert result is None
+
+
+class TestLastModifiedDays:
+    """last_modified_days calculation."""
+
+    def test_last_modified_days(self, tmp_path: Path) -> None:
+        """GIVEN folder with signal and child mtime 3 days ago, THEN last_modified_days == 3."""
+        # Create a .git dir so signal is detected
+        (tmp_path / ".git").mkdir()
+        child = tmp_path / "some_file.txt"
+        child.write_text("content")
+
+        # Patch getmtime to return 3 days ago for all children
+        three_days_ago = time.time() - 3 * 86400
+
+        original_getmtime = os.path.getmtime
+
+        def fake_getmtime(path: str) -> float:
+            return three_days_ago
+
+        with patch("os.path.getmtime", side_effect=fake_getmtime):
+            result = detect_project_signature(str(tmp_path))
+
+        assert result is not None
+        assert result.last_modified_days == 3
+
+    def test_last_modified_days_none_on_empty_signals_folder(self, tmp_path: Path) -> None:
+        """With signal but empty folder, last_modified_days may be None."""
+        # Make a project path so signal fires from path (not file listing)
+        mis_path = tmp_path / "Mis_proyectos" / "emptyapp"
+        mis_path.mkdir(parents=True)
+
+        result = detect_project_signature(str(mis_path))
+        assert result is not None
+        # last_modified_days may be None (empty folder) or an integer
+        assert result.last_modified_days is None or isinstance(
+            result.last_modified_days, int
+        )
+
+
+class TestProjectSignatureShape:
+    """Returned ProjectSignature has correct shape."""
+
+    def test_path_field_matches_input(self, tmp_path: Path) -> None:
+        """THEN result.path equals the input path."""
+        (tmp_path / ".git").mkdir()
+        result = detect_project_signature(str(tmp_path))
+        assert result is not None
+        assert result.path == str(tmp_path)
+
+    def test_signals_is_tuple(self, tmp_path: Path) -> None:
+        """THEN result.signals is a tuple."""
+        (tmp_path / ".git").mkdir()
+        result = detect_project_signature(str(tmp_path))
+        assert result is not None
+        assert isinstance(result.signals, tuple)


### PR DESCRIPTION
## Summary

The "Asesor de Orden" module had three `shutil.rmtree` paths that bypassed the Recycle Bin and had no project awareness — a user could delete a live project from "Orden General" with one click and no warning specific to "this looks like a project". Same class of bomb the duplicate finder had before PR #32, but for whole folder trees.

This PR replaces all three paths with `send2trash`, adds a project-signature detector service, and introduces a type-to-confirm dialog for the Orden General flow when the target folder looks like a project.

**The user can still delete dead projects** — the goal is *intelligent friction*, not blocking.

## Changes

- **domain/constants.py + domain/models.py**: 13 `PROJECT_SIGNAL_*` constants + `PROJECT_SIGNAL_LABELS` dict + `ProjectSignature` frozen dataclass.
- **services/project_detector.py** (NEW): pure `detect_project_signature(path) -> ProjectSignature | None`. Detects signals based on path patterns (`\Mis_proyectos\`, `\Local Sites\`) and direct-child markers (`.git`, `package.json`, `composer.json`, `pyproject.toml`, `Cargo.toml`, `go.mod`, `pom.xml`, `*.sln`, `*.csproj`, `wp-config.php`, `Gemfile`). No recursion, no symlink follow, safe on `PermissionError`.
- **infrastructure/file_system.py**: extends `_log_deletion(path, source, fallback_rename)` backward-compatibly. Adds `safe_delete_dir(path, source)` using `send2trash` with audit log. On D: drive `TrashPermissionError`, falls back to in-place rename `.UNSAFE-CANT-RECYCLE.{ISO}.bak` and surfaces a warning.
- **ui/presenters/asesor_presenter.py**: `delete_items` rewritten as queue-based async-by-callback. On project signature → `view.show_project_confirm_dialog`. `move_items` similar with lighter `show_project_move_warning_dialog`. `delete_deep_entry` and `bulk_delete_safe` use `safe_delete_dir` (no project dialog — entries pre-classified by deep_scanner).
- **ui/views/asesor_view.py**: `show_project_confirm_dialog` (CTkToplevel + Entry + modal grab + case-sensitive type-to-confirm + resolved guard against double-fire). `show_project_move_warning_dialog` wraps `messagebox.askyesno`.

## Safety properties

- `shutil.rmtree` is now ZERO occurrences in `asesor_presenter.py` (invariant I1 verified)
- Every successful deletion writes a JSONL line to `~/.cleanacelerai/deleted.log` with `source` (`asesor.orden-general` / `.limpieza-profunda` / `.bulk-safe`) and optional `fallback_rename: true`
- Type-to-confirm dialog only appears in `delete_items` (Orden General), not in deep-clean paths (invariant I3)
- W-2 fix included: `_finish_delete_summary` shows BOTH fallback warning AND error summary if both occur (previously the `elif` swallowed errors when fallbacks were present)

## Test plan

- [x] `pytest cleanacelerai/tests/` — 193/193 pass (135 baseline + 58 new for this PR)
- [x] Invariant I1: `rg "shutil.rmtree" src/ui/presenters/asesor_presenter.py` → 0 matches
- [x] Invariant I3: `detect_project_signature` only called from `delete_items` and `move_items`
- [ ] Manual: delete a plain folder from Orden General → goes to Recycle Bin, log entry written
- [ ] Manual: delete `D:\Mis_proyectos\<folder>` from Orden General → type-to-confirm dialog appears, wrong text keeps Confirm disabled
- [ ] Manual: cancel the dialog → folder untouched, no log entry
- [ ] Manual: move a project folder → warning dialog appears (not type-to-confirm)
- [ ] Manual: Limpieza Profunda single + bulk → no project dialog, log entries with correct source

Built via SDD cycle (proposal → spec → design → tasks → apply → verify → archive) including a W-2 regression fix. All artifacts persisted to engram.
