### PR TITLE
fix(infra): normalize path separators before send2trash (Asesor delete bug)

### DIFF
--- a/cleanacelerai/src/infrastructure/file_system.py
+++ b/cleanacelerai/src/infrastructure/file_system.py
@@ -68,6 +68,11 @@ def safe_delete(path: str) -> tuple[bool, str]:
         Tuple of (success: bool, error_message: str).
         error_message is empty on success.
     """
+    # Normalize separators — Tk filedialog returns forward-slash paths on
+    # Windows; send2trash + '\\?\' extended-path prefix demands consistent
+    # backslashes, otherwise [Errno 3] is raised.
+    path = os.path.normpath(path)
+
     # MS-DOS hechizo for problematic paths
     if path.lower().endswith("\nul") or len(path) > 250:
         try:
@@ -88,7 +93,7 @@ def safe_delete(path: str) -> tuple[bool, str]:
         except (PermissionError, OSError):
             pass  # Best-effort: remove read-only flag
         _log_deletion(path)
-        send2trash(str(path))
+        send2trash(path)
         return True, ""
     except PermissionError as e:
         return False, f"Permiso denegado: {e}"
@@ -117,12 +122,18 @@ def safe_delete_dir(path: str, source: str = "asesor") -> tuple[bool, str]:
         (True, 'FALLBACK_RENAME:{new_path}') on fallback rename success.
         (False, error_msg) on hard failure.
     """
+    # Normalize separators BEFORE any operation. Tk filedialog returns
+    # forward-slash paths on Windows, and send2trash internally prepends the
+    # extended-path prefix '\\?\' which requires consistent backslashes,
+    # otherwise [Errno 3] "ruta no encontrada" is raised.
+    path = os.path.normpath(path)
+
     if not os.path.isdir(path):
         return False, f"No es un directorio: {path}"
 
     try:
         _log_deletion(path, source=source, fallback_rename=False)
-        send2trash(str(path))
+        send2trash(path)
         return True, ""
     except TrashPermissionError:
         # Drive does not allow Recycle Bin (e.g., D: on some configs).

--- a/cleanacelerai/tests/test_file_system.py
+++ b/cleanacelerai/tests/test_file_system.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
 from unittest.mock import MagicMock, call, patch
 
@@ -323,4 +324,32 @@ class TestSafeDeleteDir:
         args, kwargs = first_call_kwargs
         assert kwargs.get("source") == "asesor.limpieza-profunda" or (
             len(args) > 1 and args[1] == "asesor.limpieza-profunda"
+        )
+
+    def test_safe_delete_dir_normalizes_forward_slashes(self, tmp_path: Path) -> None:
+        """Regression: Tk filedialog.askdirectory returns forward-slash paths on
+        Windows. send2trash then internally prepends the extended-path prefix
+        '\\\\?\\' which DEMANDS consistent backslashes, and the call fails with
+        '[Errno 3] El sistema no puede encontrar la ruta especificada'.
+
+        safe_delete_dir MUST normalize the path before passing to send2trash."""
+        target = tmp_path / "mydir"
+        target.mkdir()
+        target_str = str(target)
+
+        # Build a forward-slash version (no-op on POSIX, real swap on Windows)
+        forward = target_str.replace("\\", "/")
+        expected_normalized = os.path.normpath(forward)
+
+        with (
+            patch("src.infrastructure.file_system.send2trash") as mock_trash,
+            patch("src.infrastructure.file_system._log_deletion"),
+        ):
+            ok, err = safe_delete_dir(forward)
+
+        assert ok is True, f"safe_delete_dir failed: {err}"
+        called_path = mock_trash.call_args[0][0]
+        assert called_path == expected_normalized, (
+            f"send2trash received non-normalized path. "
+            f"Expected: {expected_normalized!r}, got: {called_path!r}"
         )


### PR DESCRIPTION
## Summary

Live bug discovered while smoke-testing PR #35 (Asesor de Orden). The new type-to-confirm dialog opened correctly and the project signature was detected, but clicking Eliminar on `D:\Mis_proyectos\<folder>` produced `0 elemento(s) eliminado(s) / 1 error(es)` with `[Errno 3] El sistema no puede encontrar la ruta especificada`. The folder stayed on disk despite the audit log entry being written.

## Root cause

Tk `filedialog.askdirectory()` returns paths with **forward slashes** on Windows. `os.path.join` later pegs children with a single backslash, producing mixed-separator paths like:

```
C:/Users/Josep/AppData/Local/Temp/cleanacelerai-smoke\fake-project
```

`send2trash` then internally prepends the extended-path prefix `\\?\`, which **requires consistent backslashes**. The mixed path collapses with Errno 3.

Audit-log evidence from the failed attempts (paths visibly mixed):
```
"path": "C:/Users/Josep/AppData/Local/Temp/cleanacelerai-smoke\\fake-project"
```

## Fix

`os.path.normpath(path)` as the **first operation** in both `safe_delete` and `safe_delete_dir`, before any logging, chmod, or send2trash call. On Windows this converts every `/` to `\` consistently, so the extended-path prefix works correctly.

## Why the existing 248 tests didn't catch it

pytest's `tmp_path` fixture returns **backslash-native** paths on Windows. Every test in `test_file_system.py` was passing already-normalized paths in. The mixed-separator case is only produced by Tk `filedialog`, which has no fixture in the suite.

Added regression `test_safe_delete_dir_normalizes_forward_slashes`: explicitly fabricates a forward-slash path and asserts that `send2trash` receives the normalized form.

## Test plan

- [x] `pytest cleanacelerai/tests/` — **249/249 pass** (248 prior + 1 regression)
- [x] Live smoke: open Cleanacelerai → Asesor de Orden → analyse `C:\Users\Josep\AppData\Local\Temp\cleanacelerai-smoke` → select `fake-project` → click Eliminar → type-to-confirm dialog → confirm → **folder goes to Recycle Bin**, log entry has fully-backslashed path
- [x] `safe_delete` (files) also gets the normalization as defense-in-depth — file-deletion path was not observed to fail but the same class of bug was latent
