### PR TITLE
fix(ui): reorder confirm-dialog buttons + Esc binding (Asesor)

### DIFF
--- a/cleanacelerai/src/ui/views/asesor_view.py
+++ b/cleanacelerai/src/ui/views/asesor_view.py
@@ -517,15 +517,11 @@ class AsesorView(ctk.CTkFrame):
         btn_row = ctk.CTkFrame(w, fg_color="transparent")
         btn_row.pack(padx=20, pady=20, fill="x")
 
-        btn_cancel = ctk.CTkButton(
-            btn_row,
-            text="Cancelar",
-            fg_color=COLOR_BORDER,
-            hover_color=COLOR_TEXT_MUTED,
-            command=lambda: _resolve(False),
-        )
-        btn_cancel.pack(side="right", padx=(10, 0))
-
+        # Button order: Cancel (left, safe escape) | Eliminar (right, destructive).
+        # Pack Eliminar FIRST with side="right" so it sits at the rightmost edge;
+        # Cancel packed second with side="right" sits to its LEFT. This puts the
+        # destructive action where the user has to skip past Cancel to reach it,
+        # reducing the risk of muscle-memory clicks right after typing the name.
         btn_confirm = ctk.CTkButton(
             btn_row,
             text="Eliminar",
@@ -536,6 +532,15 @@ class AsesorView(ctk.CTkFrame):
         )
         btn_confirm.pack(side="right")
 
+        btn_cancel = ctk.CTkButton(
+            btn_row,
+            text="Cancelar",
+            fg_color=COLOR_BORDER,
+            hover_color=COLOR_TEXT_MUTED,
+            command=lambda: _resolve(False),
+        )
+        btn_cancel.pack(side="right", padx=(0, 10))
+
         def _on_entry_change(*_args: object) -> None:
             if entry.get() == folder_name:  # case-sensitive exact match
                 btn_confirm.configure(state="normal")
@@ -543,6 +548,9 @@ class AsesorView(ctk.CTkFrame):
                 btn_confirm.configure(state="disabled")
 
         entry.bind("<KeyRelease>", _on_entry_change)
+
+        # Esc -> cancel (keyboard escape route)
+        w.bind("<Escape>", lambda _e: _resolve(False))
 
         # Window close button (X) -> cancel
         w.protocol("WM_DELETE_WINDOW", lambda: _resolve(False))

--- a/cleanacelerai/tests/test_asesor_presenter.py
+++ b/cleanacelerai/tests/test_asesor_presenter.py
@@ -389,6 +389,70 @@ class TestDeleteItems:
 
         mock_sdd.assert_not_called()
 
+    def test_delete_items_dialog_cancelled_does_not_redialog(self) -> None:
+        """Regression: cancelling the project-confirm dialog must advance the
+        queue. Previously _cb only popped the queue on confirmed=True, so
+        cancel caused the SAME item to re-trigger the dialog forever — user
+        observed during smoke test of PR #35: clicking Cancel reopened the
+        dialog until they typed the name and clicked Eliminar to escape."""
+        presenter, view = self._make_presenter()
+
+        sig = ProjectSignature(
+            path=r"C:\Mis_proyectos\myapp",
+            signals=("inside-mis-proyectos",),
+            last_modified_days=1,
+        )
+
+        with (
+            patch("src.ui.presenters.asesor_presenter.safe_delete_dir") as mock_sdd,
+            patch("src.ui.presenters.asesor_presenter.detect_project_signature", return_value=sig),
+            patch("os.path.isdir", return_value=True),
+        ):
+            presenter.delete_items([("id1", r"C:\Mis_proyectos\myapp", "myapp")])
+            assert len(view.show_project_confirm_dialog_calls) == 1
+            _, on_confirm = view.show_project_confirm_dialog_calls[0]
+            on_confirm(False)
+
+            assert len(view.show_project_confirm_dialog_calls) == 1, (
+                f"Dialog re-opened after cancel — queue did not advance. "
+                f"Total dialog calls: {len(view.show_project_confirm_dialog_calls)}"
+            )
+
+        mock_sdd.assert_not_called()
+
+    def test_delete_items_cancel_then_next_item_processed(self) -> None:
+        """After cancel on a project item, the NEXT queued item must still
+        be processed. Verifies the queue keeps draining past the cancelled one."""
+        presenter, view = self._make_presenter()
+
+        sig = ProjectSignature(
+            path=r"C:\Mis_proyectos\myapp",
+            signals=("inside-mis-proyectos",),
+            last_modified_days=1,
+        )
+
+        def sig_lookup(path: str):
+            return sig if "myapp" in path else None
+
+        items = [
+            ("id1", r"C:\Mis_proyectos\myapp", "myapp"),
+            ("id2", r"C:\plain\folder", "folder"),
+        ]
+
+        with (
+            patch("src.ui.presenters.asesor_presenter.safe_delete_dir", return_value=(True, "")) as mock_sdd,
+            patch("src.ui.presenters.asesor_presenter.detect_project_signature", side_effect=sig_lookup),
+            patch("os.path.isdir", return_value=True),
+        ):
+            presenter.delete_items(items)
+            assert len(view.show_project_confirm_dialog_calls) == 1
+            _, on_confirm = view.show_project_confirm_dialog_calls[0]
+            on_confirm(False)
+
+        mock_sdd.assert_called_once()
+        called_path = mock_sdd.call_args[0][0]
+        assert "folder" in called_path
+
     def test_delete_items_source_is_orden_general(self) -> None:
         """safe_delete_dir must be called with source='asesor.orden-general'."""
         presenter, view = self._make_presenter()


### PR DESCRIPTION
## Summary

User reported during smoke-testing PR #35 that after typing the project name in the confirm dialog (which enables the Eliminar button), they clicked Eliminar thinking it was Cancel — the folder was deleted. The buttons were packed in an inverted layout that made the dominant red action sit immediately to the left of where the user's eyes landed after typing:

```
Before:  [Eliminar (red, left)] [Cancelar (grey, right)]
                ↑ muscle-memory click after typing the name
```

## Changes

### `asesor_view.py` — `show_project_confirm_dialog`

- **Reorder buttons** so Eliminar sits at the rightmost edge and Cancelar to its left. The user has to consciously skip past Cancelar to reach the destructive action.
- **Bind `<Escape>` → Cancelar** so the user has a keyboard escape route at any point (consistent with `WM_DELETE_WINDOW` already binding to cancel).

```
After:   [Cancelar (grey, left)] [Eliminar (red, right)]
```

### `test_asesor_presenter.py` — two regression tests added

Both pass against the current code (the `_cb` callback already pops the queue regardless of `confirmed=True/False`), but they serve as a safety net for future refactors:

- `test_delete_items_dialog_cancelled_does_not_redialog`: cancelling does NOT reopen the dialog
- `test_delete_items_cancel_then_next_item_processed`: after cancelling one item, the next queued item is still processed normally

## Test plan

- [x] `pytest cleanacelerai/tests/` — **251/251 pass** (249 prior + 2 regression)
- [ ] Manual smoke: open Cleanacelerai → Asesor → Orden General → analyze a folder containing a project-signature directory → click Eliminar Selección → confirm dialog opens → verify Cancelar is on the LEFT and Eliminar on the RIGHT
- [ ] Manual smoke: press `Esc` in the dialog → dialog closes, no deletion, no log entry
- [ ] Manual smoke: type the folder name → Eliminar button enables → click Cancelar (on the left) → no deletion happens, queue advances

## Why this happened

UI changes have 0% automated coverage per project policy. SDD verify on PR #35 caught zero CRITICAL issues because no test exercised the *visual* layout. The bug was only discoverable by a human clicking the actual rendered dialog — which is exactly what the smoke test gate caught (working as intended).
